### PR TITLE
Add architecture diagram and user stories

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -70,6 +70,10 @@ Build a self-updating, agent-fed, static knowledge hub—a "personal intelligenc
 
 ---
 
+### 3a. Architecture Diagram
+
+See [`docs/architecture.mmd`](docs/architecture.mmd) for a mermaid diagram depicting the data flow between automation scripts, content folders, and the GitHub Actions workflow.
+
 ### 4. Automation Scripts (CI)
 
 | Script               | Purpose                                                                | Invoked By       |

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,14 @@
+flowchart TD
+    Agents["Agents Commit Files"] -->|"push"| Inbox["content/inbox/"]
+    Inbox -->|"classify-inbox.mjs"| Classified["content/<section>/"]
+    AgentsManifest["content/agents/*.yml"] -->|"agent-bus.mjs"| GitHubIssue["#agent-bus Issue"]
+    RepoScan["fetch-gh-repos.mjs"] --> ToolsDir["content/tools/"]
+    Classified -->|"build-insights.mjs"| Insights["*.insight.md"]
+    ToolsDir -->|"Astro Build"| Site["Static Site"]
+    Insights -->|"Astro Build"| Site
+    GitHubActions["GitHub Actions CI"] -->|"run scripts"| RepoScan
+    GitHubActions -->|"run scripts"| ClassifyScript[classify-inbox.mjs]
+    GitHubActions -->|"run scripts"| InsightsScript[build-insights.mjs]
+    GitHubActions -->|"run scripts"| AgentBusScript[agent-bus.mjs]
+    GitHubActions -->|"build"| Site
+    Site -->|"deploy"| GitHubPages["GitHub Pages"]

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1,0 +1,18 @@
+# User Stories
+
+## Core Features
+
+1. **Inbox Classification**
+   - *As an agent, I want to drop a file in the inbox so it can be automatically classified into the appropriate content section.*
+
+2. **Agent Status Tracking**
+   - *As an agent, I want to update my manifest so the latest status appears in the Agent Bus issue.*
+
+3. **Tool Aggregation**
+   - *As a user, I want to browse a tools page generated from GitHub repositories so I can discover available utilities.*
+
+4. **Insight Generation**
+   - *As a reader, I want to see daily insight summaries synthesised from new content so I can keep up with changes quickly.*
+
+5. **Automated Build and Deploy**
+   - *As a maintainer, I want GitHub Actions to handle classification, insights, and site deployment after each push.*


### PR DESCRIPTION
## Summary
- document the overall data flow with a new Mermaid diagram
- outline core user stories for the Personal Intelligence Node
- reference the diagram from the execution plan

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e1e9da440832ab2d524b7c3cc0663