### PR TITLE
Implement agent bus script

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -75,6 +75,25 @@ Build a self-updating, agent-fed, static knowledge hub—a "personal intelligenc
 
 See [`docs/architecture.mmd`](docs/architecture.mmd) for a mermaid diagram depicting the data flow between automation scripts, content folders, and the GitHub Actions workflow.
 
+### 3b. Agent Manifest Schema
+
+Agent status files live in `content/agents/` and must conform to the schema in
+[`docs/agent-manifest-schema.yml`](docs/agent-manifest-schema.yml). A minimal
+example looks like:
+
+```yaml
+id: codex-agent
+name: Codex Agent
+owner: "@adrian"
+role: Repository automation
+status: active        # active | idle | offline | error
+last_updated: 2024-01-01T00:00:00Z
+description: Handles GitHub automation tasks.
+```
+
+The `agent-bus.mjs` script reads these manifests and updates the `#agent-bus`
+GitHub Issue with a summary table.
+
 ### 4. Automation Scripts (CI)
 
 | Script               | Purpose                                                                | Invoked By       |

--- a/content/agents/codex.yml
+++ b/content/agents/codex.yml
@@ -1,0 +1,7 @@
+id: codex-agent
+name: Codex Agent
+owner: "@adrian"
+role: Repository automation
+status: active
+last_updated: 2024-01-01T00:00:00Z
+description: Handles GitHub automation tasks.

--- a/docs/agent-manifest-schema.yml
+++ b/docs/agent-manifest-schema.yml
@@ -1,0 +1,26 @@
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - id
+  - name
+  - status
+  - last_updated
+properties:
+  id:
+    type: string
+    description: Unique short identifier
+  name:
+    type: string
+  role:
+    type: string
+  owner:
+    type: string
+    description: GitHub username of maintainer
+  status:
+    type: string
+    enum: [active, idle, offline, error]
+  last_updated:
+    type: string
+    format: date-time
+  description:
+    type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "personal-intelligence-node",
       "version": "0.0.1",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.2.4",
         "vitest": "^3.2.4"
@@ -2316,6 +2319,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",
     "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "yaml": "^2.8.0"
   }
 }

--- a/scripts/agent-bus.mjs
+++ b/scripts/agent-bus.mjs
@@ -1,1 +1,100 @@
-console.log('agent-bus placeholder');
+import fs from 'fs/promises';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { parse } from 'yaml';
+
+const GH_TOKEN = process.env.GH_TOKEN;
+const REPO = process.env.GH_REPO || process.env.GITHUB_REPOSITORY;
+
+const headers = GH_TOKEN
+  ? {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${GH_TOKEN}`,
+    }
+  : null;
+
+function requireEnv() {
+  if (!headers) throw new Error('GH_TOKEN not set');
+  if (!REPO) throw new Error('GH_REPO or GITHUB_REPOSITORY not set');
+}
+
+async function loadManifests(dir = path.join('content', 'agents')) {
+  const files = await fs.readdir(dir);
+  const manifests = [];
+  for (const file of files) {
+    if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+    const data = await fs.readFile(path.join(dir, file), 'utf8');
+    const doc = parse(data);
+    manifests.push({ file, ...doc });
+  }
+  return manifests;
+}
+
+function manifestsToMarkdown(manifests) {
+  if (manifests.length === 0) return 'No agents found.';
+  let md = '| id | status | last updated | owner | role |\n|---|---|---|---|---|\n';
+  for (const m of manifests) {
+    md += `| ${m.id} | ${m.status} | ${m.last_updated} | ${m.owner || ''} | ${m.role || ''} |\n`;
+  }
+  return md;
+}
+
+async function getIssueNumber(title, owner, repo) {
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues?per_page=100&state=open`, { headers });
+  if (!res.ok) throw new Error(`Failed to list issues: ${res.status}`);
+  const issues = await res.json();
+  const found = issues.find((i) => i.title.toLowerCase() === title.toLowerCase());
+  return found ? found.number : null;
+}
+
+async function createIssue(title, body, owner, repo) {
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ title, body }),
+  });
+  if (!res.ok) throw new Error(`Failed to create issue: ${res.status}`);
+  const issue = await res.json();
+  return issue.number;
+}
+
+async function updateIssue(number, body, owner, repo) {
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/${number}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({ body }),
+  });
+  if (!res.ok) throw new Error(`Failed to update issue: ${res.status}`);
+}
+
+async function main() {
+  requireEnv();
+  const [owner, repo] = REPO.split('/');
+  const manifests = await loadManifests();
+  const body = manifestsToMarkdown(manifests);
+  const title = 'agent-bus';
+  const num = await getIssueNumber(title, owner, repo);
+  if (num) {
+    await updateIssue(num, body, owner, repo);
+    console.log(`Updated issue #${num}`);
+  } else {
+    const newNum = await createIssue(title, body, owner, repo);
+    console.log(`Created issue #${newNum}`);
+  }
+}
+
+export {
+  loadManifests,
+  manifestsToMarkdown,
+  getIssueNumber,
+  createIssue,
+  updateIssue,
+  main,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tasks.yml
+++ b/tasks.yml
@@ -190,7 +190,7 @@ phases:
     component: "Automation Scripts"
     dependencies: [8]
     priority: 2
-    status: pending
+    status: done
     command: "node scripts/agent-bus.mjs"
     task_id: "PIN-DEV-3"
     area: Development


### PR DESCRIPTION
## Summary
- finalize the YAML schema for agent manifests
- document the schema and example in `PLAN.md`
- add sample agent manifest
- implement `agent-bus.mjs` to update the `#agent-bus` issue
- mark Agent Bus task as done
- add `yaml` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e280694f8832aa988047949fc6b04