### PR TITLE
Add header with section nav

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,9 +1,29 @@
 ---
-import NavBar from '../components/NavBar.astro';
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/tools/', label: 'Tools' },
+  { href: '/logs/', label: 'Logs' },
+  { href: '/garden/', label: 'Garden' },
+  { href: '/mirror/', label: 'Mirror' },
+  { href: '/resume/', label: 'Resume' },
+  { href: '/agents/', label: 'Agents' },
+  { href: '/codex/', label: 'Codex' },
+];
 ---
 <html lang="en">
   <body class="min-h-screen flex flex-col">
-    <NavBar />
+    <header class="bg-gray-800 text-white">
+      <div class="container mx-auto flex flex-col md:flex-row items-center justify-between p-4">
+        <a href="/" class="text-xl font-semibold mb-2 md:mb-0">Personal Intelligence Node</a>
+        <nav class="flex flex-wrap gap-4">
+          {links.map(link => (
+            <a href={link.href} class="hover:underline">
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </header>
     <main class="flex-grow">
       <slot />
     </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,24 @@
 ---
+import BaseLayout from '../layouts/Base.astro';
+
+const sections = [
+  { href: '/tools/', title: 'Tools', description: 'Code and utilities.' },
+  { href: '/logs/', title: 'Logs', description: 'Journals and transcripts.' },
+  { href: '/garden/', title: 'Garden', description: 'Zettels and notes.' },
+  { href: '/mirror/', title: 'Mirror', description: 'Narrative and creative work.' },
+  { href: '/resume/', title: 'Resume', description: 'Professional profile.' },
+  { href: '/agents/', title: 'Agents', description: 'Agent manifests.' },
+  { href: '/codex/', title: 'Codex', description: 'Agent blueprints.' },
+];
 ---
-<html>
-  <head>
-    <title>Personal Intelligence Node</title>
-  </head>
-  <body>
-    <h1>Welcome to the Personal Intelligence Node</h1>
-  </body>
-</html>
+<BaseLayout>
+  <h1 class="text-2xl font-bold my-4">Personal Intelligence Node</h1>
+  <div class="grid gap-4 md:grid-cols-2">
+    {sections.map(section => (
+      <a href={section.href} class="block p-4 border rounded-lg hover:bg-gray-50">
+        <h2 class="text-xl font-semibold">{section.title}</h2>
+        <p class="text-sm text-gray-600">{section.description}</p>
+      </a>
+    ))}
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- update Base layout with a responsive header linking to all sections
- rebuild index page using Base layout with summaries for each section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e4a99f37c832a8f3a3d5b2327d759