### PR TITLE
Add RSS feed generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
       - run: node scripts/build-insights.mjs
       - run: node scripts/agent-bus.mjs
       - run: npm run build
+      - run: node scripts/build-rss.mjs
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages

--- a/PLAN.md
+++ b/PLAN.md
@@ -104,6 +104,7 @@ GitHub Issue with a summary table.
 | `classify-inbox.mjs` | For every file in `content/inbox/`, call LLM → `{section,tags}`; move file accordingly. Confidence < 0.8 ⇒ move to `untagged/`. | Before build step     |
 | `build-insights.mjs` | Parse new/changed markdown (logs, garden, mirror); generate `<slug>.insight.md` with summary + cross-links.                     | After classification  |
 | `build-search-index.mjs` | Generate `public/search-index.json` for client-side Lunr search. | Before build step |
+| `build-rss.mjs` | Generate `public/rss.xml` feed from markdown metadata. | Before deploy step |
 | `agent-bus.mjs`      | Read `content/agents/*.yml`, update or create GitHub Issue `#agent-bus` with latest agent statuses.                             | Last step in workflow |
 
 ---

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -7,6 +7,7 @@ This directory contains documentation for the Node.js scripts that run during th
 | `fetch-gh-repos.mjs` | Fetches public repositories from GitHub and creates tool markdown files. | `GH_TOKEN`, optional `GH_USER` |
 | `classify-inbox.mjs` | Uses OpenAI to categorise files dropped into `content/inbox`. | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
 | `build-insights.mjs` | Placeholder for generating periodic insights from content. | none |
+| `build-rss.mjs` | Generates `public/rss.xml` from markdown metadata. | none |
 | `agent-bus.mjs` | Aggregates agent manifests and posts a summary issue on GitHub. | `GH_TOKEN`, optional `GH_REPO` |
 
 See the individual files below for further details.

--- a/docs/scripts/build-rss.md
+++ b/docs/scripts/build-rss.md
@@ -1,0 +1,11 @@
+# build-rss.mjs
+
+Generates an RSS 2.0 feed from all markdown files under `content/` and writes it to `public/rss.xml`.
+
+This script walks the `content` directory recursively, reads front-matter using `gray-matter`, and sorts entries by their `date` field (or file modification time). The output RSS contains basic metadata like title, link, description and publication date.
+
+No environment variables are required. You can run the script manually with:
+
+```bash
+node scripts/build-rss.mjs
+```

--- a/scripts/build-rss.mjs
+++ b/scripts/build-rss.mjs
@@ -1,0 +1,80 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import matter from 'gray-matter';
+
+const BASE_URL = process.env.BASE_URL || 'https://adrianwedd.github.io';
+
+async function collectMarkdown(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectMarkdown(res)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(res);
+    }
+  }
+  return files;
+}
+
+function slugify(filePath) {
+  const relative = filePath.replace(/^content\//, '');
+  return '/' + relative.replace(/\.md$/, '') + '/';
+}
+
+function escape(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildXml(items) {
+  const lines = [];
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push('<rss version="2.0">');
+  lines.push('<channel>');
+  lines.push('<title>Personal Intelligence Node</title>');
+  lines.push(`<link>${BASE_URL}/</link>`);
+  lines.push('<description>Recent updates</description>');
+  for (const item of items) {
+    lines.push('<item>');
+    lines.push(`<title>${escape(item.title)}</title>`);
+    lines.push(`<link>${BASE_URL}${item.slug}</link>`);
+    lines.push(`<pubDate>${item.date.toUTCString()}</pubDate>`);
+    if (item.description) {
+      lines.push(`<description>${escape(item.description)}</description>`);
+    }
+    lines.push('</item>');
+  }
+  lines.push('</channel>');
+  lines.push('</rss>');
+  return lines.join('');
+}
+
+async function main() {
+  const files = await collectMarkdown('content');
+  const items = [];
+  for (const file of files) {
+    const raw = await fs.readFile(file, 'utf8');
+    const { data, content } = matter(raw);
+    const stats = await fs.stat(file);
+    const title = data.title || path.basename(file, '.md');
+    const description = data.description || content.split('\n')[0];
+    const date = data.date ? new Date(data.date) : stats.mtime;
+    items.push({ title, description, slug: slugify(file), date });
+  }
+  items.sort((a, b) => b.date - a.date);
+  const xml = buildXml(items);
+  await fs.mkdir('public', { recursive: true });
+  await fs.writeFile('public/rss.xml', xml);
+  console.log('Wrote public/rss.xml');
+}
+
+export { collectMarkdown, slugify, buildXml, main };
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/fetch-gh-repos.mjs
+++ b/scripts/fetch-gh-repos.mjs
@@ -28,10 +28,11 @@ async function fetchRepos(login) {
   const repos = [];
   let page = 1;
   const perPage = 100;
-  while (true) {
+  for (;;) {
     const url = `https://api.github.com/users/${login}/repos?per_page=${perPage}&page=${page}`;
     const res = await fetch(url, { headers });
-    if (!res.ok) throw new Error(`Failed to fetch repos page ${page}: ${res.status}`);
+    if (!res.ok)
+      throw new Error(`Failed to fetch repos page ${page}: ${res.status}`);
     const data = await res.json();
     repos.push(...data);
     if (data.length < perPage) break;
@@ -48,17 +49,21 @@ function repoToMarkdown(repo) {
 async function main() {
   const login = await getLogin();
   const repos = await fetchRepos(login);
-  const tools = repos.filter(r => Array.isArray(r.topics) && r.topics.includes('tool'));
+  const tools = repos.filter(
+    (r) => Array.isArray(r.topics) && r.topics.includes('tool')
+  );
 
   const dir = path.join('content', 'tools');
   await fs.mkdir(dir, { recursive: true });
 
-  await Promise.all(tools.map(async (repo) => {
-    const md = repoToMarkdown(repo);
-    const filePath = path.join(dir, `${repo.name}.md`);
-    await fs.writeFile(filePath, md);
-    console.log(`Wrote ${filePath}`);
-  }));
+  await Promise.all(
+    tools.map(async (repo) => {
+      const md = repoToMarkdown(repo);
+      const filePath = path.join(dir, `${repo.name}.md`);
+      await fs.writeFile(filePath, md);
+      console.log(`Wrote ${filePath}`);
+    })
+  );
 }
 
 export { getLogin, fetchRepos, repoToMarkdown, main };
@@ -69,4 +74,3 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
     process.exit(1);
   });
 }
-

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -8,6 +8,7 @@ const links = [
   { href: '/resume/', label: 'Resume' },
   { href: '/agents/', label: 'Agents' },
   { href: '/codex/', label: 'Codex' },
+  { href: '/rss.xml', label: 'RSS' },
 ];
 ---
 <html lang="en">

--- a/tasks.yml
+++ b/tasks.yml
@@ -481,3 +481,23 @@ phases:
       - 'Users can search without a backend.'
     assigned_to: codex-agent
     epic: 'Phase 5: UI Expansion'
+
+  - id: 24
+    title: 'RSS Feed Generation'
+    description: 'Produce an RSS feed from markdown metadata for subscribers.'
+    component: 'Automation'
+    dependencies: [5]
+    priority: 3
+    status: done
+    command: null
+    task_id: 'PIN-AUTO-4'
+    area: Deployment
+    actionable_steps:
+      - 'Create build-rss.mjs to output rss.xml.'
+      - 'Add script invocation to deploy workflow before publishing.'
+      - 'Link the feed in site navigation.'
+    acceptance_criteria:
+      - 'Workflow writes `public/rss.xml`.'
+      - 'Site exposes an RSS link.'
+    assigned_to: codex-agent
+    epic: 'Phase 6: Iterative Growth'


### PR DESCRIPTION
## Summary
- generate `public/rss.xml` from Markdown via new script `build-rss.mjs`
- call the RSS script in the deploy workflow before publishing
- expose the RSS link in site navigation
- document the script and update project plan and tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e5c6bdde0832a9e7a7c8069051d28