### PR TITLE
Log tasks 47-50

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -937,3 +937,89 @@ phases:
       - 'Test coverage for `build-insights.mjs` is maintained or improved.'
     assigned_to: codex-agent
     epic: 'Phase 6: Iterative Growth'
+  - id: 47
+    title: 'Implement DNS Verification for Agents'
+    description: 'Provide agents with the ability to verify DNS records to confirm their custom domain configurations.'
+    component: 'Automation Scripts'
+    dependencies: [15]
+    priority: 3
+    status: pending
+    command: 'node scripts/verify-dns.mjs'
+    task_id: 'PIN-VERIFY-1'
+    area: 'Verification'
+    actionable_steps:
+      - 'Create a new script `scripts/verify-dns.mjs` that takes a domain as input.'
+      - 'The script should use a library or shell out to `dig` to check for `A` and `CNAME` records.'
+      - 'The script should output whether the DNS records are correctly configured for GitHub Pages.'
+    acceptance_criteria:
+      - 'Agents can run the script to verify their custom domain settings.'
+      - 'The script provides clear success or failure messages.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 6: Iterative Growth'
+
+  - id: 48
+    title: 'Debug and Fix Workflow Errors'
+    description: 'Systematically identify and resolve errors occurring in the GitHub Actions workflow to ensure reliable and successful builds and deployments.'
+    component: 'CI/CD'
+    dependencies: [3]
+    priority: 5
+    status: in_progress
+    command: null
+    task_id: 'PIN-DEBUG-1'
+    area: 'Debugging'
+    actionable_steps:
+      - 'Analyze workflow logs from failed runs to identify specific error messages and failing steps.'
+      - 'Replicate failures locally where possible by running the scripts with the same inputs and environment variables.'
+      - 'Add more detailed logging to scripts to trace execution flow and variable states.'
+      - 'Create isolated test cases that specifically target the failing conditions.'
+      - 'Incrementally apply fixes and re-run the workflow to verify the solution.'
+    acceptance_criteria:
+      - 'The `deploy.yml` workflow completes successfully without errors.'
+      - 'Root causes of previous failures are identified and documented.'
+      - 'The system is more robust against similar future failures.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 7: Debugging and Stability'
+
+  - id: 49
+    title: 'Enhance Script Error Handling and Reporting'
+    description: 'Improve error handling within all automation scripts to provide clearer, more actionable error messages and prevent silent failures.'
+    component: 'Automation Scripts'
+    dependencies: [30, 31, 32, 33]
+    priority: 4
+    status: pending
+    command: null
+    task_id: 'PIN-ROBUST-6'
+    area: 'Robustness'
+    actionable_steps:
+      - 'Review all `try...catch` blocks in the automation scripts.'
+      - 'Ensure that caught errors are logged with sufficient context (e.g., file path, API endpoint).'
+      - 'Implement a consistent error logging format across all scripts, potentially using a centralized logger.'
+      - 'For critical errors, ensure the script exits with a non-zero status code to fail the CI step explicitly.'
+    acceptance_criteria:
+      - 'Script failures produce clear, informative log output in the CI.'
+      - 'Silent failures are eliminated.'
+      - 'It is easier to diagnose the cause of a script failure from the workflow logs.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 7: Debugging and Stability'
+
+  - id: 50
+    title: 'Create a Debugging Guide for Agents'
+    description: 'Develop a `DEBUGGING.md` document that provides a step-by-step guide for agents (and humans) to diagnose and fix common issues with the automation pipeline.'
+    component: 'Documentation'
+    dependencies: [48]
+    priority: 3
+    status: pending
+    command: null
+    task_id: 'PIN-DOC-3'
+    area: 'Documentation'
+    actionable_steps:
+      - 'Create a `DEBUGGING.md` file in the `docs/` directory.'
+      - 'Document common failure scenarios (e.g., API key errors, file not found, LLM response malformed).'
+      - 'Provide instructions on how to read workflow logs and identify the failing script.'
+      - 'Include steps for running scripts locally to reproduce issues.'
+      - 'Link to this guide from the main `README.md`.'
+    acceptance_criteria:
+      - 'A clear and concise debugging guide is available to all contributors.'
+      - 'The time to diagnose and resolve common issues is reduced.'
+    assigned_to: 'human-operator'
+    epic: 'Phase 7: Debugging and Stability'

--- a/test/classify-inbox.test.mjs
+++ b/test/classify-inbox.test.mjs
@@ -1,13 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  readFile,
-  writeFile,
-  mkdir,
-  readdir,
-  rename,
-} from '../scripts/utils/file-utils.mjs';
+import fs from 'fs/promises';
 
-// Mock fs before any imports
+// Mock fs before importing the module under test
 vi.mock('fs/promises');
 
 // Import the module to be tested
@@ -40,7 +34,7 @@ describe('classify-inbox.mjs', () => {
     process.env.OPENAI_API_KEY = 'test-key';
 
     // Mock implementations
-    readdir.mockImplementation((dirPath, options) => {
+    fs.readdir.mockImplementation((dirPath, options) => {
       if (options && options.withFileTypes) {
         // Return Dirent-like objects for 'content' directory
         if (dirPath === 'content') {
@@ -58,10 +52,10 @@ describe('classify-inbox.mjs', () => {
         mockFiles.filter((d) => !d.isDirectory()).map((d) => d.name)
       );
     });
-    readFile.mockResolvedValue('Test content');
-    mkdir.mockResolvedValue(undefined);
-    rename.mockResolvedValue(undefined);
-    writeFile.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('Test content');
+    fs.mkdir.mockResolvedValue(undefined);
+    fs.rename.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
     global.fetch = vi.fn();
   });
 
@@ -88,17 +82,17 @@ describe('classify-inbox.mjs', () => {
       confidence: 0.9,
     });
     await classifyInbox.main();
-    expect(rename).toHaveBeenCalledWith(
+    expect(fs.rename).toHaveBeenCalledWith(
       expect.stringContaining('file1.txt'),
       expect.stringContaining('content/garden/file1.txt')
     );
-    expect(writeFile).toHaveBeenCalled();
+    expect(fs.writeFile).toHaveBeenCalled();
   });
 
   it('should move a file to untagged for low confidence', async () => {
     mockOpenAIResponse({ section: 'garden', tags: [], confidence: 0.7 });
     await classifyInbox.main();
-    expect(rename).toHaveBeenCalledWith(
+    expect(fs.rename).toHaveBeenCalledWith(
       expect.stringContaining('file1.txt'),
       expect.stringContaining('content/untagged/file1.txt')
     );
@@ -107,7 +101,7 @@ describe('classify-inbox.mjs', () => {
   it('should move a file to untagged for unknown section', async () => {
     mockOpenAIResponse({ section: 'unknown', tags: [], confidence: 0.9 });
     await classifyInbox.main();
-    expect(rename).toHaveBeenCalledWith(
+    expect(fs.rename).toHaveBeenCalledWith(
       expect.stringContaining('file1.txt'),
       expect.stringContaining('content/untagged/file1.txt')
     );
@@ -121,7 +115,7 @@ describe('classify-inbox.mjs', () => {
       }),
     });
     await classifyInbox.main();
-    expect(rename).toHaveBeenCalledWith(
+    expect(fs.rename).toHaveBeenCalledWith(
       expect.stringContaining('file1.txt'),
       expect.stringContaining('content/inbox/failed/file1.txt')
     );
@@ -130,7 +124,7 @@ describe('classify-inbox.mjs', () => {
   it('should move a file to failed on malformed (missing keys) response', async () => {
     mockOpenAIResponse({ section: 'garden' });
     await classifyInbox.main();
-    expect(rename).toHaveBeenCalledWith(
+    expect(fs.rename).toHaveBeenCalledWith(
       expect.stringContaining('file1.txt'),
       expect.stringContaining('content/inbox/failed/file1.txt')
     );
@@ -139,7 +133,7 @@ describe('classify-inbox.mjs', () => {
   it('should move a file to failed on OpenAI API error', async () => {
     mockOpenAIResponse({}, 500);
     await classifyInbox.main();
-    expect(rename).toHaveBeenCalledWith(
+    expect(fs.rename).toHaveBeenCalledWith(
       expect.stringContaining('file1.txt'),
       expect.stringContaining('content/inbox/failed/file1.txt')
     );
@@ -148,6 +142,6 @@ describe('classify-inbox.mjs', () => {
   it('should skip classification if API key is not set', async () => {
     delete process.env.OPENAI_API_KEY;
     await classifyInbox.main();
-    expect(readdir).not.toHaveBeenCalled();
+    expect(fs.readdir).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- append new tasks 47-50 to `tasks.yml`
- fix mocking in `classify-inbox` unit tests to use `fs.promises`

## Testing
- `npm ci`
- `npm test` *(fails: 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5497ec8832abd4e0ae7fc7dea2b