### PR TITLE
Add CI debugging guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Format the codebase using Prettier:
 npm run format
 ```
 
-See `docs/scripts` for details on each automation script.
+See `docs/scripts` for details on each automation script. For troubleshooting CI failures, consult [docs/DEBUGGING.md](docs/DEBUGGING.md).
 
 ## License
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,34 @@
+# Debugging CI/CD Workflows
+
+This guide collects tips for diagnosing failures in the GitHub Actions pipeline and running scripts locally.
+
+## Common Failure Scenarios
+
+- **Missing environment variables** – most scripts rely on secrets like `GH_TOKEN` or `OPENAI_API_KEY`. Ensure these are configured under *Settings → Secrets* in the repository.
+- **File not found errors** – check that expected paths exist (e.g. `content/inbox` or `content/tools`).
+- **Malformed LLM responses** – the `classify-inbox` script expects valid JSON from OpenAI. A broken or truncated response will cause it to skip files.
+- **Dependency issues** – if a script cannot find a package, run `npm ci` to install all dependencies exactly as defined in `package-lock.json`.
+
+## Reading Workflow Logs
+
+1. Open the **Actions** tab on GitHub and select the failing workflow run.
+2. Expand the job with the red ❌ icon to view the failing step.
+3. Click **Show logs** to inspect console output. Errors usually mention which script failed.
+4. Cross‑reference the script name with the documentation in `docs/scripts` for troubleshooting tips.
+
+## Running Scripts Locally
+
+1. Install dependencies with `npm ci`.
+2. Export any required environment variables, for example:
+   ```bash
+   export GH_TOKEN=...
+   export OPENAI_API_KEY=...
+   ```
+3. Execute the script directly using Node 20:
+   ```bash
+   node scripts/<script>.mjs
+   ```
+   Replace `<script>` with the file you want to test, such as `classify-inbox`.
+4. Check the terminal output for errors and iterate until the command succeeds.
+
+Running scripts locally mirrors the CI environment and helps isolate issues before pushing commits.


### PR DESCRIPTION
## Summary
- document common CI failures and troubleshooting steps
- link debugging guide from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ef9053e3c832aa290a8229c44c6b8