### PR TITLE
Refactor classify script to use shared LLM utility

### DIFF
--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -1,8 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { pathToFileURL } from 'url';
-
-const MODEL = process.env.OPENAI_MODEL || 'gpt-3.5-turbo-1106';
+import { callOpenAI } from './utils/llm-api.mjs';
 
 // Function to dynamically discover content sections
 async function getDynamicSections() {
@@ -33,28 +32,6 @@ async function buildPrompt(content) {
   );
 }
 
-async function callOpenAI(prompt) {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error('OPENAI_API_KEY not set');
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      messages: [{ role: 'user', content: prompt }],
-      temperature: 0,
-    }),
-  });
-  if (!res.ok) {
-    const errorBody = await res.text();
-    throw new Error(`OpenAI API error ${res.status}: ${errorBody}`);
-  }
-  const data = await res.json();
-  return data.choices[0].message.content.trim();
-}
 
 async function classifyFile(filePath) {
   let content;


### PR DESCRIPTION
## Summary
- use `callOpenAI` from `scripts/utils/llm-api.mjs`
- remove old API helper from `classify-inbox.mjs`
- mock `../scripts/utils/llm-api.mjs` in unit tests

This continues the refactor described in task *Refactor LLM API Calls into Dedicated Utility* (`tasks.yml` ID 36).

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686ef9f2f33c832a939cd0d55db8a3b4