### PR TITLE
Remove outdated test comment

### DIFF
--- a/test/build-insights.test.mjs
+++ b/test/build-insights.test.mjs
@@ -24,8 +24,6 @@ vi.mock('../scripts/utils/file-utils.mjs', () => ({
   rename: vi.fn(),
 }));
 
-// Alias imports from the mocked LLM API
-
 // Import the module to be tested
 import * as buildInsights from '../scripts/build-insights.mjs';
 import { callOpenAI } from '../scripts/utils/llm-api.mjs';


### PR DESCRIPTION
## Summary
- clean up `build-insights.test.mjs` by removing a stale alias comment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686efed75b18832a9d94d73258c7ec47