### PR TITLE
Handle missing GH_TOKEN in scripts

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -5,6 +5,7 @@ This guide collects tips for diagnosing failures in the GitHub Actions pipeline 
 ## Common Failure Scenarios
 
 - **Missing environment variables** – most scripts rely on secrets like `GH_TOKEN` or `OPENAI_API_KEY`. Ensure these are configured under *Settings → Secrets* in the repository.
+- **Secrets unavailable on forks** – GitHub does not expose repository secrets to workflows triggered from forked pull requests. Scripts that rely on `GH_TOKEN` will now log `GH_TOKEN not set; skipping` instead of failing.
 - **File not found errors** – check that expected paths exist (e.g. `content/inbox` or `content/tools`).
 - **Malformed LLM responses** – the `classify-inbox` script expects valid JSON from OpenAI. A broken or truncated response will cause it to skip files.
 - **Dependency issues** – if a script cannot find a package, run `npm ci` to install all dependencies exactly as defined in `package-lock.json`.

--- a/scripts/agent-bus.mjs
+++ b/scripts/agent-bus.mjs
@@ -12,10 +12,7 @@ async function loadManifests(dir = path.join('content', 'agents')) {
   try {
     files = await fs.readdir(dir);
   } catch (err) {
-    log.error(
-      `Error reading agent manifests directory ${dir}:`,
-      err.message
-    );
+    log.error(`Error reading agent manifests directory ${dir}:`, err.message);
     return [];
   }
   const manifests = [];
@@ -81,6 +78,10 @@ async function updateIssue(number, body, owner, repo) {
 }
 
 async function main() {
+  if (!process.env.GH_TOKEN) {
+    log.error('GH_TOKEN not set; skipping agent-bus update');
+    return;
+  }
   if (!REPO) throw new Error('GH_REPO or GITHUB_REPOSITORY not set'); // Moved check here
   const [owner, repo] = REPO.split('/');
   const manifests = await loadManifests();

--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -15,10 +15,7 @@ async function getDynamicSections() {
       .filter((name) => !['inbox', 'untagged'].includes(name)); // Filter out special directories
     return sections;
   } catch (err) {
-    log.error(
-      `Error reading content directory ${contentDir}:`,
-      err.message
-    );
+    log.error(`Error reading content directory ${contentDir}:`, err.message);
     return []; // Return empty array to prevent further errors
   }
 }
@@ -32,7 +29,6 @@ async function buildPrompt(content) {
     `Text:\n${content}`
   );
 }
-
 
 async function classifyFile(filePath) {
   let content;
@@ -74,10 +70,7 @@ async function moveFile(src, destDir) {
   try {
     await fs.mkdir(destDir, { recursive: true });
   } catch (err) {
-    log.error(
-      `Error creating destination directory ${destDir}:`,
-      err.message
-    );
+    log.error(`Error creating destination directory ${destDir}:`, err.message);
     throw err;
   }
   const dest = path.join(destDir, path.basename(src));
@@ -179,10 +172,7 @@ async function main() {
             try {
               await fs.writeFile(filePath, fm + data);
             } catch (err) {
-              log.error(
-                `Error writing tags to file ${filePath}:`,
-                err.message
-              );
+              log.error(`Error writing tags to file ${filePath}:`, err.message);
               targetDir = failedDir; // Move to failed if cannot write tags
             }
           }

--- a/scripts/fetch-gh-repos.mjs
+++ b/scripts/fetch-gh-repos.mjs
@@ -30,6 +30,10 @@ function repoToMarkdown(repo) {
 }
 
 async function main() {
+  if (!process.env.GH_TOKEN) {
+    log.error('GH_TOKEN not set; skipping fetch-gh-repos');
+    return;
+  }
   const login = await getLogin();
   const repos = await fetchRepos(login);
   const tools = repos.filter(

--- a/test/build-insights.test.mjs
+++ b/test/build-insights.test.mjs
@@ -77,7 +77,7 @@ describe('build-insights.mjs', () => {
 
   it('processMarkdownFile should handle LLM API errors gracefully', async () => {
     callOpenAI.mockRejectedValue(new Error('LLM API error'));
-  const consoleErrorSpy = vi
+    const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
     const filePath = path.join('content', 'garden', 'file1.md');

--- a/test/fetch-gh-repos.test.mjs
+++ b/test/fetch-gh-repos.test.mjs
@@ -93,4 +93,15 @@ describe('fetch-gh-repos', () => {
     mkdir.mockRestore();
     write.mockRestore();
   });
+
+  it('main skips when GH_TOKEN not set', async () => {
+    delete process.env.GH_TOKEN;
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await main();
+    expect(error).toHaveBeenCalledWith(
+      '[ERROR]',
+      'GH_TOKEN not set; skipping fetch-gh-repos'
+    );
+    error.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- skip fetch-gh-repos when `GH_TOKEN` is absent
- skip agent-bus updates when `GH_TOKEN` is absent
- fix lint warnings and update tests
- document fork secret behaviour in `DEBUGGING.md`

## Testing
- `npm test`
- `npm run lint`
- `python scripts/validate-tasks.py`
- `yamllint tasks.yml`

------
https://chatgpt.com/codex/tasks/task_e_686f00c83ca8832aa1f6e3e003f93dc0