### PR TITLE
Add tasks and clarify plan phase

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -189,6 +189,7 @@ jobs:
 | 4. Process Hardening & Agent Bus | Status visibility & quality gate | • Enforce branch protection on `main` requiring passing checks and one approving review. • Design simple YAML manifest schema. • Implement `agent-bus.mjs` to update Issue.             |
 | 5. UI Expansion                  | Flesh out components & pages     | • Build ToolCard, AgentDiagram, etc. • Style with Tailwind. • Populate content folders.                                                                                                 |
 | 6. Iterative Growth              | Continuous enhancement           | • Add more scripts (dataset stats, changelog diffing). • Hook additional agents via commits. • Refine design/branding. • Introduce `npm audit` checks and Slack alerts for CI failures. |
+| 7. Debugging & Stability         | Harden automation reliability    | • Document troubleshooting workflow. • Add file locking and dead-letter queues. • Perform dependency audits and performance tests. |
 
 ---
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -1023,3 +1023,100 @@ phases:
       - 'The time to diagnose and resolve common issues is reduced.'
     assigned_to: 'human-operator'
     epic: 'Phase 7: Debugging and Stability'
+
+  - id: 54
+    title: 'Comprehensive Dependency Audit'
+    description: 'Perform a comprehensive audit of all npm dependencies to identify any known vulnerabilities. This goes beyond a simple `npm audit` and should involve checking each dependency against vulnerability databases.'
+    component: 'Security'
+    dependencies: [25]
+    priority: 5
+    status: pending
+    command: null
+    task_id: 'PIN-SEC-4'
+    area: 'Security'
+    actionable_steps:
+      - 'Use a tool like Snyk or Dependabot to scan the project for vulnerabilities.'
+      - 'Review the results and create a plan to address any high-priority vulnerabilities.'
+      - 'Update the `package.json` file with the patched versions of the dependencies.'
+    acceptance_criteria:
+      - 'A comprehensive vulnerability scan has been performed.'
+      - 'A plan to address any identified vulnerabilities has been created.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 7: Debugging and Stability'
+
+  - id: 55
+    title: 'Implement a File Locking Mechanism'
+    description: 'Implement a file locking mechanism in `classify-inbox.mjs` to prevent race conditions when multiple instances of the script are running simultaneously. This can be achieved by creating a lock file before processing a file and deleting it afterward.'
+    component: 'Automation Scripts'
+    dependencies: [6]
+    priority: 4
+    status: pending
+    command: null
+    task_id: 'PIN-ROBUST-7'
+    area: 'Robustness'
+    actionable_steps:
+      - 'In `classify-inbox.mjs`, before processing a file, check for the existence of a corresponding `.lock` file.'
+      - 'If a lock file exists, skip the file.'
+      - 'If no lock file exists, create one.'
+      - 'After the file has been processed, delete the lock file.'
+    acceptance_criteria:
+      - 'The script no longer has the potential for race conditions when processing files.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 7: Debugging and Stability'
+
+  - id: 56
+    title: 'Add a Dead-Letter Queue for Insights'
+    description: 'In `build-insights.mjs`, if the LLM fails to generate a summary, move the original file to a `content/insights-failed` directory for manual review and reprocessing.'
+    component: 'Automation Scripts'
+    dependencies: [18]
+    priority: 3
+    status: pending
+    command: null
+    task_id: 'PIN-ROBUST-8'
+    area: 'Robustness'
+    actionable_steps:
+      - 'In `build-insights.mjs`, if the `callOpenAI` function throws an error, move the original file to a `content/insights-failed` directory.'
+      - 'Log the error with the path to the failed file.'
+    acceptance_criteria:
+      - 'Failed insight generations are handled gracefully.'
+      - 'The original file is preserved for manual review and reprocessing.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 7: Debugging and Stability'
+
+  - id: 57
+    title: 'Enhance the `CONTRIBUTING.md` Guide'
+    description: 'Enhance the `CONTRIBUTING.md` guide with more detailed information on the project\'s branching strategy, commit message format, and code style guidelines.'
+    component: 'Documentation'
+    dependencies: [45]
+    priority: 2
+    status: pending
+    command: null
+    task_id: 'PIN-DOC-4'
+    area: 'Documentation'
+    actionable_steps:
+      - 'Add a section on the branching strategy (e.g., GitFlow).'
+      - 'Add a section on the preferred commit message format (e.g., Conventional Commits).'
+      - 'Add a section on the code style guidelines, with examples.'
+    acceptance_criteria:
+      - 'The `CONTRIBUTING.md` guide is more comprehensive and provides clearer instructions for new contributors.'
+    assigned_to: 'human-operator'
+    epic: 'Phase 6: Iterative Growth'
+
+  - id: 58
+    title: 'Implement Performance Testing for Automation Scripts'
+    description: 'Implement performance testing for the automation scripts to identify and address any bottlenecks. This will involve creating a large number of test files and measuring the execution time of the scripts.'
+    component: 'Testing'
+    dependencies: [19]
+    priority: 2
+    status: pending
+    command: null
+    task_id: 'PIN-QA-16'
+    area: 'Testing'
+    actionable_steps:
+      - 'Create a script to generate a large number of test files (e.g., 1000+).'
+      - 'Run the automation scripts against the test files and measure the execution time.'
+      - 'Identify any bottlenecks and create a plan to address them.'
+    acceptance_criteria:
+      - 'The performance of the automation scripts has been measured and any bottlenecks have been identified.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 6: Iterative Growth'


### PR DESCRIPTION
## Summary
- add tasks for dependency auditing, file locking, dead-letter queue, docs, and performance testing
- note a new "Debugging & Stability" phase in the execution plan

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f40a7b5b4832ab6121da73603b463