### PR TITLE
Add usage examples for automation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Format the codebase using Prettier:
 npm run format
 ```
 
-See `docs/scripts` for details on each automation script. For troubleshooting CI failures, consult [docs/DEBUGGING.md](docs/DEBUGGING.md).
+See [docs/scripts/README.md](docs/scripts/README.md) for examples and environment variables for each automation script. For troubleshooting CI failures, consult [docs/DEBUGGING.md](docs/DEBUGGING.md).
 
 ## License
 

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,13 +1,15 @@
 # Automation Scripts
 
+
 This directory contains documentation for the Node.js scripts that run during the CI workflow. Each script is written in ESM and executed with Node 20.
+All pages include example commands and sample output so you can reproduce the results locally.
 
 | Script               | Description                                                              | Environment Variables                     |
 | -------------------- | ------------------------------------------------------------------------ | ----------------------------------------- |
 | `fetch-gh-repos.mjs` | Fetches public repositories from GitHub and creates tool markdown files. | `GH_TOKEN`, optional `GH_USER`            |
 | `classify-inbox.mjs` | Uses OpenAI to categorise files dropped into `content/inbox`.            | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
 | `build-insights.mjs` | Summarises changed markdown files, validates the summary with `markdownlint`, and writes `.insight.md` outputs (failed files move to `content/insights-failed/`). | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
-| `build-rss.mjs`      | Generates `public/rss.xml` from markdown metadata.                       | none                                      |
+| `build-rss.mjs` | Generates `public/rss.xml` from markdown metadata. | optional `BASE_URL` |
 | `agent-bus.mjs`      | Aggregates agent manifests and posts a summary issue on GitHub.          | `GH_TOKEN`, optional `GH_REPO`            |
 
 See the individual files below for further details.

--- a/docs/scripts/agent-bus.md
+++ b/docs/scripts/agent-bus.md
@@ -10,5 +10,11 @@ Reads all YAML agent manifests in `content/agents`, aggregates their status, and
 Run manually with:
 
 ```bash
-node scripts/agent-bus.mjs
+GH_TOKEN=ghp_yourtoken GH_REPO=owner/repo node scripts/agent-bus.mjs
+```
+
+Example output:
+
+```text
+[INFO] Created issue #12
 ```

--- a/docs/scripts/build-insights.md
+++ b/docs/scripts/build-insights.md
@@ -16,5 +16,11 @@ Output is logged with `[INFO]`, `[WARN]`, and `[ERROR]` prefixes via `logger.mjs
 Run manually with:
 
 ```bash
-node scripts/build-insights.mjs
+OPENAI_API_KEY=sk-test node scripts/build-insights.mjs "content/garden/note.md"
+```
+
+Example output:
+
+```text
+[INFO] Generated insight for note.md -> note.insight.md
 ```

--- a/docs/scripts/build-rss.md
+++ b/docs/scripts/build-rss.md
@@ -4,8 +4,14 @@ Generates an RSS 2.0 feed from all markdown files under `content/` and writes it
 
 This script walks the `content` directory recursively, reads front-matter using `gray-matter`, and sorts entries by their `date` field (or file modification time). The output RSS contains basic metadata like title, link, description and publication date.
 
-No environment variables are required. You can run the script manually with:
+No required environment variables. Optionally set `BASE_URL` to override the root URL in the feed (defaults to `https://adrianwedd.github.io`). You can run the script manually with:
 
 ```bash
-node scripts/build-rss.mjs
+BASE_URL=https://example.com node scripts/build-rss.mjs
+```
+
+Example output:
+
+```text
+Wrote public/rss.xml
 ```

--- a/docs/scripts/classify-inbox.md
+++ b/docs/scripts/classify-inbox.md
@@ -10,5 +10,13 @@ Reads files from `content/inbox`, asks OpenAI to determine which section they be
 Run manually with:
 
 ```bash
-node scripts/classify-inbox.mjs
+OPENAI_API_KEY=sk-test node scripts/classify-inbox.mjs
+```
+
+Place a markdown file in `content/inbox/` before running.
+
+Example output:
+
+```text
+[INFO] Moved note.md to content/garden/note.md
 ```

--- a/docs/scripts/fetch-gh-repos.md
+++ b/docs/scripts/fetch-gh-repos.md
@@ -10,5 +10,11 @@ Fetches repositories from GitHub for a given user and generates markdown files i
 Run manually with:
 
 ```bash
-node scripts/fetch-gh-repos.mjs
+GH_TOKEN=ghp_yourtoken GH_USER=octocat node scripts/fetch-gh-repos.mjs
+```
+
+Example output:
+
+```text
+[INFO] Wrote content/tools/example-repo.md
 ```


### PR DESCRIPTION
## Summary
- expand all script docs with example commands and expected output
- describe optional `BASE_URL` in RSS script docs
- link detailed script docs in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f72506af8832a9f7988e296dab63c