### PR TITLE
Improve classify-inbox logging

### DIFF
--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -42,7 +42,9 @@ async function classifyFile(filePath) {
     throw err; // Re-throw to be caught by main's try-catch
   }
 
+  log.debug(`Classifying file ${filePath}`);
   const reply = await callOpenAI(await buildPrompt(content));
+  log.debug(`Raw response for ${filePath}: ${reply}`);
   let result;
   try {
     result = JSON.parse(reply);
@@ -93,6 +95,7 @@ async function main() {
   const failedDir = path.join(inboxDir, 'failed');
 
   const dynamicSections = await getDynamicSections(); // Get dynamic sections for validation
+  log.debug(`Available sections: ${dynamicSections.join(', ')}`);
 
   // Get files to process from arguments or read from inboxDir
   let filesToProcess = [];
@@ -145,6 +148,7 @@ async function main() {
 
   for (const name of filesToProcess) {
     const filePath = path.join(inboxDir, name);
+    log.info(`Processing ${name}`);
     let targetDir;
 
     try {

--- a/scripts/utils/llm-api.mjs
+++ b/scripts/utils/llm-api.mjs
@@ -5,6 +5,9 @@ const MODEL = process.env.OPENAI_MODEL || 'gpt-3.5-turbo-1106';
 export async function callOpenAI(prompt) {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error('OPENAI_API_KEY not set');
+  log.debug(
+    `Calling OpenAI model ${MODEL} with prompt length ${prompt.length}`
+  );
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -23,5 +26,6 @@ export async function callOpenAI(prompt) {
     throw new Error(`OpenAI API error ${res.status}: ${errorBody}`);
   }
   const data = await res.json();
+  log.debug('OpenAI response received');
   return data.choices[0].message.content.trim();
 }

--- a/scripts/utils/logger.mjs
+++ b/scripts/utils/logger.mjs
@@ -2,4 +2,7 @@ export const log = {
   info: (...args) => console.log('[INFO]', ...args),
   warn: (...args) => console.warn('[WARN]', ...args),
   error: (...args) => console.error('[ERROR]', ...args),
+  debug: (...args) => {
+    if (process.env.DEBUG) console.debug('[DEBUG]', ...args);
+  },
 };

--- a/test/classify-inbox.test.mjs
+++ b/test/classify-inbox.test.mjs
@@ -143,4 +143,14 @@ describe('classify-inbox.mjs', () => {
       expect.stringContaining('OPENAI_API_KEY not set')
     );
   });
+
+  it('logs processing steps', async () => {
+    const logSpy = vi.spyOn(console, 'log');
+    mockOpenAIResponse({ section: 'garden', tags: [], confidence: 0.9 });
+    await classifyInbox.main();
+    expect(logSpy).toHaveBeenCalledWith(
+      '[INFO]',
+      expect.stringContaining('Processing file1.txt')
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add a `debug` logger helper
- log OpenAI request/response details
- log available sections and each processed file
- test new logging behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fc19e5564832ab0325e400f9b4cb3