### PR TITLE
Add Snyk dependency scanning

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,28 @@
+name: Snyk Dependency Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@v3
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: test
+          args: --severity-threshold=high

--- a/PLAN.md
+++ b/PLAN.md
@@ -188,8 +188,8 @@ jobs:
 | 3. LLM Integration               | Classification & insights        | • Implement `classify-inbox.mjs` with chosen LLM. • Implement `build-insights.mjs`. • Store API keys in Secrets. • Dry-run on sample inbox files.                                       |
 | 4. Process Hardening & Agent Bus | Status visibility & quality gate | • Enforce branch protection on `main` requiring passing checks and one approving review. • Require Conventional Commits via a Husky `commit-msg` hook. • Design simple YAML manifest schema. • Implement `agent-bus.mjs` to update Issue.             |
 | 5. UI Expansion                  | Flesh out components & pages     | • Build ToolCard, AgentDiagram, etc. • Style with Tailwind. • Populate content folders.                                                                                                 |
-| 6. Iterative Growth              | Continuous enhancement           | • Add more scripts (dataset stats, changelog diffing). • Hook additional agents via commits. • Refine design/branding. • Introduce `npm audit` checks and Slack alerts for CI failures. |
-| 7. Debugging & Stability         | Harden automation reliability    | • Document troubleshooting workflow. • Add file locking and dead-letter queues. • Perform dependency audits and performance tests. |
+| 6. Iterative Growth              | Continuous enhancement           | • Add more scripts (dataset stats, changelog diffing). • Hook additional agents via commits. • Refine design/branding. • Introduce `npm audit` and Snyk checks with Slack alerts for CI failures. |
+| 7. Debugging & Stability         | Harden automation reliability    | • Document troubleshooting workflow. • Add file locking and dead-letter queues. • Perform dependency audits with Snyk and performance tests. |
 
 ---
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -747,7 +747,7 @@ phases:
     component: 'Automation Scripts'
     dependencies: []
     priority: 2
-    status: pending
+    status: done
     command: null
     task_id: 'PIN-MAINT-2'
     area: Maintainability
@@ -1030,7 +1030,7 @@ phases:
     component: 'Security'
     dependencies: [25]
     priority: 5
-    status: pending
+    status: done
     command: null
     task_id: 'PIN-SEC-4'
     area: 'Security'


### PR DESCRIPTION
## Summary
- add a Snyk dependency scanning workflow
- mark the dependency audit task as done
- mention Snyk checks in the implementation plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fc3fc0850832a9bfa26f807acabf7