### PR TITLE
Add debugging guide reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Format the codebase using Prettier:
 npm run format
 ```
 
-See [docs/scripts/README.md](docs/scripts/README.md) for examples and environment variables for each automation script. For troubleshooting CI failures, consult [docs/DEBUGGING.md](docs/DEBUGGING.md).
+See [docs/scripts/README.md](docs/scripts/README.md) for script usage and environment variables. Troubleshooting tips live in [docs/DEBUGGING.md](docs/DEBUGGING.md).
 
 ## License
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -4,10 +4,10 @@ This guide collects tips for diagnosing failures in the GitHub Actions pipeline 
 
 ## Common Failure Scenarios
 
-- **Missing environment variables** – most scripts rely on secrets like `GH_TOKEN` or `OPENAI_API_KEY`. Ensure these are configured under *Settings → Secrets* in the repository.
+- **Missing secrets or environment variables** – most scripts rely on `GH_TOKEN` and `OPENAI_API_KEY`. When these are undefined the pipeline may abort or skip steps. Set them under *Settings → Secrets* or export them locally.
 - **Secrets unavailable on forks** – GitHub does not expose repository secrets to workflows triggered from forked pull requests. Scripts that rely on `GH_TOKEN` will now log `GH_TOKEN not set; skipping` instead of failing.
-- **File not found errors** – check that expected paths exist (e.g. `content/inbox` or `content/tools`).
-- **Malformed LLM responses** – the `classify-inbox` script expects valid JSON from OpenAI. A broken or truncated response will cause it to skip files.
+- **File-system errors** – ensure directories like `content/inbox` exist and that the runner has write permission. Missing paths trigger `ENOENT` errors.
+- **Malformed LLM responses** – the `classify-inbox` script expects valid JSON from OpenAI. Broken or truncated output causes files to be skipped.
 - **Dependency issues** – if a script cannot find a package, run `npm ci` to install all dependencies exactly as defined in `package-lock.json`.
 
 ## Reading Workflow Logs


### PR DESCRIPTION
## Summary
- expand CI/CD debugging tips for missing secrets, file-system errors and malformed LLM output
- clarify README link to the debugging guide

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687044c61bb8832aad0afff26e0a22af