### PR TITLE
feat: add retryFetch helper for API resilience

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -189,7 +189,7 @@ jobs:
 | 4. Process Hardening & Agent Bus | Status visibility & quality gate | • Enforce branch protection on `main` requiring passing checks and one approving review. • Require Conventional Commits via a Husky `commit-msg` hook. • Design simple YAML manifest schema. • Implement `agent-bus.mjs` to update Issue.             |
 | 5. UI Expansion                  | Flesh out components & pages     | • Build ToolCard, AgentDiagram, etc. • Style with Tailwind. • Populate content folders.                                                                                                 |
 | 6. Iterative Growth              | Continuous enhancement           | • Add more scripts (dataset stats, changelog diffing). • Hook additional agents via commits. • Refine design/branding. • Introduce `npm audit` and Snyk checks with Slack alerts for CI failures. |
-| 7. Debugging & Stability         | Harden automation reliability    | • Document troubleshooting workflow. • Add file locking and dead-letter queues. • Perform dependency audits with Snyk and performance tests. |
+| 7. Debugging & Stability         | Harden automation reliability    | • Document troubleshooting workflow. • Add file locking and dead-letter queues. • Use `retryFetch` with exponential backoff for all API calls. • Perform dependency audits with Snyk and performance tests. |
 
 ---
 

--- a/scripts/utils/github.mjs
+++ b/scripts/utils/github.mjs
@@ -1,3 +1,5 @@
+import { retryFetch } from './retryFetch.mjs';
+
 export function getGitHubHeaders() {
   const GH_TOKEN = process.env.GH_TOKEN;
   if (!GH_TOKEN) {
@@ -13,20 +15,13 @@ export function getGitHubHeaders() {
 
 export async function githubFetch(url, options = {}) {
   const headers = getGitHubHeaders();
-  const res = await fetch(url, {
+  const res = await retryFetch(url, {
     ...options,
     headers: {
       ...headers,
       ...options.headers,
     },
   });
-
-  if (!res.ok) {
-    const errorBody = await res.text();
-    throw new Error(
-      `GitHub API error for ${url}: ${res.status} ${res.statusText}\n${errorBody}`
-    );
-  }
 
   return res.json();
 }

--- a/scripts/utils/llm-api.mjs
+++ b/scripts/utils/llm-api.mjs
@@ -1,4 +1,5 @@
 import { log } from './logger.mjs';
+import { retryFetch } from './retryFetch.mjs';
 
 const MODEL = process.env.OPENAI_MODEL || 'gpt-3.5-turbo-1106';
 
@@ -8,7 +9,7 @@ export async function callOpenAI(prompt) {
   log.debug(
     `Calling OpenAI model ${MODEL} with prompt length ${prompt.length}`
   );
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+  const res = await retryFetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -20,11 +21,6 @@ export async function callOpenAI(prompt) {
       temperature: 0,
     }),
   });
-  if (!res.ok) {
-    const errorBody = await res.text();
-    log.error(`OpenAI API error ${res.status}: ${errorBody}`);
-    throw new Error(`OpenAI API error ${res.status}: ${errorBody}`);
-  }
   const data = await res.json();
   log.debug('OpenAI response received');
   return data.choices[0].message.content.trim();

--- a/scripts/utils/retryFetch.mjs
+++ b/scripts/utils/retryFetch.mjs
@@ -1,0 +1,27 @@
+import { log } from './logger.mjs';
+
+export async function retryFetch(
+  url,
+  options = {},
+  { retries = 3, backoff = 500 } = {}
+) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(
+          `Fetch failed ${response.status} ${response.statusText} - ${errorBody}`
+        );
+      }
+      return response;
+    } catch (err) {
+      if (attempt === retries) throw err;
+      const delay = backoff * 2 ** attempt;
+      log.warn(
+        `Retry ${attempt + 1}/${retries} for ${url} after error: ${err.message}`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}

--- a/test/utils/github.test.mjs
+++ b/test/utils/github.test.mjs
@@ -53,7 +53,7 @@ describe('github.mjs', () => {
 
     it('should throw an error on non-ok response', async () => {
       process.env.GH_TOKEN = 'test_token';
-      global.fetch.mockResolvedValueOnce({
+      global.fetch.mockResolvedValue({
         ok: false,
         status: 404,
         statusText: 'Not Found',
@@ -61,7 +61,7 @@ describe('github.mjs', () => {
       });
 
       await expect(githubFetch('https://api.github.com/test')).rejects.toThrow(
-        'GitHub API error for https://api.github.com/test: 404 Not Found\nError: Not Found'
+        'Fetch failed 404 Not Found - Error: Not Found'
       );
     });
 


### PR DESCRIPTION
## Summary
- implement `retryFetch` utility with exponential backoff
- replace direct `fetch` in GitHub and OpenAI helpers
- log retry attempts and update tests
- document retry strategy in the execution plan

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687047828064832a803d64c82f3bc267