### PR TITLE
Increase test coverage for automation scripts

### DIFF
--- a/test/agent-bus.test.mjs
+++ b/test/agent-bus.test.mjs
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+
+vi.mock('fs/promises');
+vi.mock('../scripts/utils/github.mjs', () => ({ githubFetch: vi.fn() }));
+import { githubFetch } from '../scripts/utils/github.mjs';
+
+const loadAgentBus = async () =>
+  import('../scripts/agent-bus.mjs?' + Date.now());
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fs.readdir.mockResolvedValue(['agent.yml']);
+  fs.readFile.mockResolvedValue(
+    'id: test\nstatus: active\nlast_updated: 2025-01-01\nowner: me\nrole: tester'
+  );
+  githubFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.GH_REPO;
+  delete process.env.GH_TOKEN;
+});
+
+describe('agent-bus.mjs', () => {
+  it('loadManifests reads yaml files', async () => {
+    const agentBus = await loadAgentBus();
+    const data = await agentBus.loadManifests('content/agents');
+    expect(data[0].id).toBe('test');
+  });
+
+  it('loadManifests returns empty array on readdir error', async () => {
+    fs.readdir.mockRejectedValueOnce(new Error('bad'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const agentBus = await loadAgentBus();
+    const res = await agentBus.loadManifests('bad');
+    expect(res).toEqual([]);
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('manifestsToMarkdown formats table', async () => {
+    const agentBus = await loadAgentBus();
+    const md = agentBus.manifestsToMarkdown([
+      { id: 'x', status: 's', last_updated: 'd', owner: 'o', role: 'r' },
+    ]);
+    expect(md).toContain('| x | s | d | o | r |');
+  });
+
+  it('manifestsToMarkdown handles empty list', async () => {
+    const agentBus = await loadAgentBus();
+    expect(agentBus.manifestsToMarkdown([])).toBe('No agents found.');
+  });
+
+  it('getIssueNumber finds existing issue', async () => {
+    githubFetch.mockResolvedValueOnce([{ title: 'agent-bus', number: 5 }]);
+    const agentBus = await loadAgentBus();
+    const num = await agentBus.getIssueNumber('agent-bus', 'me', 'repo');
+    expect(num).toBe(5);
+  });
+
+  it('getIssueNumber returns null when not found', async () => {
+    githubFetch.mockResolvedValueOnce([]);
+    const agentBus = await loadAgentBus();
+    const num = await agentBus.getIssueNumber('agent-bus', 'me', 'repo');
+    expect(num).toBeNull();
+  });
+
+  it('createIssue posts to GitHub', async () => {
+    githubFetch.mockResolvedValueOnce({ number: 7 });
+    const agentBus = await loadAgentBus();
+    const num = await agentBus.createIssue('t', 'b', 'me', 'repo');
+    expect(num).toBe(7);
+    expect(githubFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/issues'),
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('updateIssue patches GitHub', async () => {
+    githubFetch.mockResolvedValueOnce({});
+    const agentBus = await loadAgentBus();
+    await agentBus.updateIssue(3, 'b', 'me', 'repo');
+    expect(githubFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/issues/3'),
+      expect.objectContaining({ method: 'PATCH' })
+    );
+  });
+
+  it('main creates a new issue when none exists', async () => {
+    process.env.GH_TOKEN = 't';
+    process.env.GH_REPO = 'me/repo';
+    githubFetch.mockResolvedValueOnce([]).mockResolvedValueOnce({ number: 8 });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const agentBus = await loadAgentBus();
+    await agentBus.main();
+    expect(githubFetch).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[INFO]',
+      expect.stringContaining('Created')
+    );
+  });
+
+  it('main updates an existing issue', async () => {
+    process.env.GH_TOKEN = 't';
+    process.env.GH_REPO = 'me/repo';
+    githubFetch
+      .mockResolvedValueOnce([{ title: 'agent-bus', number: 2 }])
+      .mockResolvedValueOnce({});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const agentBus = await loadAgentBus();
+    await agentBus.main();
+    expect(githubFetch).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[INFO]',
+      expect.stringContaining('Updated')
+    );
+  });
+
+  it('main logs error when GH_TOKEN missing', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.GH_REPO = 'me/repo';
+    const agentBus = await loadAgentBus();
+    await agentBus.main();
+    expect(errSpy).toHaveBeenCalledWith(
+      '[ERROR]',
+      expect.stringContaining('GH_TOKEN not set')
+    );
+  });
+
+  it('main throws when repo not set', async () => {
+    process.env.GH_TOKEN = 't';
+    const agentBus = await loadAgentBus();
+    await expect(agentBus.main()).rejects.toThrow(
+      'GH_REPO or GITHUB_REPOSITORY not set'
+    );
+  });
+});

--- a/test/classify-inbox-errors.test.mjs
+++ b/test/classify-inbox-errors.test.mjs
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+
+vi.mock('fs/promises');
+vi.mock('../scripts/utils/llm-api.mjs', () => ({ callOpenAI: vi.fn() }));
+vi.mock('../scripts/utils/sanitize-markdown.mjs', () => ({
+  sanitizeMarkdown: (s) => s,
+}));
+
+import {
+  classifyFile,
+  moveFile,
+  getDynamicSections,
+} from '../scripts/classify-inbox.mjs';
+import { callOpenAI } from '../scripts/utils/llm-api.mjs';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fs.readFile.mockResolvedValue('content');
+  fs.writeFile.mockResolvedValue();
+  fs.unlink.mockResolvedValue();
+  fs.mkdir.mockResolvedValue();
+  callOpenAI.mockResolvedValue(
+    JSON.stringify({ section: 'garden', tags: [], confidence: 0.9 })
+  );
+  fs.readdir.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('classify-inbox error paths', () => {
+  it('classifyFile throws on read error', async () => {
+    fs.readFile.mockRejectedValueOnce(new Error('fail'));
+    await expect(classifyFile('x')).rejects.toThrow('fail');
+  });
+
+  it('classifyFile throws on invalid JSON', async () => {
+    callOpenAI.mockResolvedValueOnce('bad');
+    await expect(classifyFile('x')).rejects.toThrow('Invalid JSON');
+  });
+
+  it('classifyFile throws on missing keys', async () => {
+    callOpenAI.mockResolvedValueOnce(JSON.stringify({ section: 'g' }));
+    await expect(classifyFile('x')).rejects.toThrow('Malformed response');
+  });
+
+  it('classifyFile throws on invalid confidence', async () => {
+    callOpenAI.mockResolvedValueOnce(
+      JSON.stringify({ section: 'g', tags: [], confidence: 2 })
+    );
+    await expect(classifyFile('x')).rejects.toThrow('Invalid confidence');
+  });
+
+  it('classifyFile throws on invalid tags', async () => {
+    callOpenAI.mockResolvedValueOnce(
+      JSON.stringify({ section: 'g', tags: 'bad', confidence: 0.9 })
+    );
+    await expect(classifyFile('x')).rejects.toThrow('Invalid tags');
+  });
+
+  it('moveFile cleans up on write failure', async () => {
+    fs.writeFile.mockRejectedValueOnce(new Error('wfail'));
+    await expect(moveFile('src.txt', 'dest')).rejects.toThrow('wfail');
+    expect(fs.unlink).toHaveBeenCalled();
+  });
+
+  it('moveFile cleans up on unlink source failure', async () => {
+    fs.unlink.mockImplementationOnce((p) => {
+      if (p === 'src.txt') throw new Error('ufail');
+      return Promise.resolve();
+    });
+    await expect(moveFile('src.txt', 'dest')).rejects.toThrow('ufail');
+    expect(fs.unlink).toHaveBeenCalled();
+  });
+
+  it('getDynamicSections returns empty list on error', async () => {
+    fs.readdir.mockRejectedValueOnce(new Error('err'));
+    const secs = await getDynamicSections();
+    expect(secs).toEqual([]);
+  });
+});

--- a/test/fetch-gh-repos.test.mjs
+++ b/test/fetch-gh-repos.test.mjs
@@ -104,4 +104,35 @@ describe('fetch-gh-repos', () => {
     );
     error.mockRestore();
   });
+  it('main throws when mkdir fails', async () => {
+    mockFetch([{ login: 'user' }, []]);
+    const mkdir = vi.spyOn(fs, 'mkdir').mockRejectedValue(new Error('mkerr'));
+    await expect(main()).rejects.toThrow('mkerr');
+    mkdir.mockRestore();
+  });
+
+  it('main logs error when writeFile fails', async () => {
+    mockFetch([
+      { login: 'user' },
+      [
+        {
+          name: 'tool1',
+          html_url: 'u',
+          description: 'd',
+          updated_at: 't',
+          topics: ['tool'],
+        },
+      ],
+    ]);
+    vi.spyOn(fs, 'mkdir').mockResolvedValue();
+    const write = vi.spyOn(fs, 'writeFile').mockRejectedValue(new Error('wr'));
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await main();
+    expect(err).toHaveBeenCalledWith(
+      '[ERROR]',
+      expect.stringContaining('Error writing file'),
+      'wr'
+    );
+    write.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- add new Vitest files for agent-bus and classify-inbox edge cases
- extend fetch-gh-repos tests for failure scenarios
- cover additional inbox behaviours
- achieve >90% overall coverage

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68704b4ea118832a9b104c10e37ed98d