### PR TITLE
Use streaming file reads for large Markdown processing

### DIFF
--- a/scripts/build-insights.mjs
+++ b/scripts/build-insights.mjs
@@ -1,7 +1,7 @@
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { log } from './utils/logger.mjs';
-import { readFile, writeFile, readdir, mkdir, rename } from './utils/file-utils.mjs';
+import { readFileStream, writeFile, readdir, mkdir, rename } from './utils/file-utils.mjs';
 import { callOpenAI } from './utils/llm-api.mjs';
 import { lint } from 'markdownlint/promise';
 import { sanitizeMarkdown } from './utils/sanitize-markdown.mjs';
@@ -51,7 +51,7 @@ async function moveToFailed(srcPath) {
 }
 
 async function processMarkdownFile(filePath) {
-  const content = await readFile(filePath, 'utf8');
+  const content = await readFileStream(filePath);
   const fileName = path.basename(filePath);
   const dirName = path.dirname(filePath);
 

--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { readFileStream } from './utils/file-utils.mjs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { callOpenAI } from './utils/llm-api.mjs';
@@ -34,7 +35,7 @@ async function buildPrompt(content) {
 async function classifyFile(filePath) {
   let content;
   try {
-    content = await fs.readFile(filePath, 'utf8');
+    content = await readFileStream(filePath);
   } catch (err) {
     log.error(
       `Error reading file ${filePath} for classification:`,
@@ -80,7 +81,7 @@ async function moveFile(src, destDir, tags = []) {
   const dest = path.join(destDir, path.basename(src));
   let data;
   try {
-    data = await fs.readFile(src, 'utf8');
+    data = await readFileStream(src);
   } catch (err) {
     log.error(`Error reading file ${src}:`, err.message);
     throw err;

--- a/scripts/utils/file-utils.mjs
+++ b/scripts/utils/file-utils.mjs
@@ -1,18 +1,34 @@
-import fs from 'fs/promises';
+import fsPromises from 'fs/promises';
+import fs from 'fs';
 import { log } from './logger.mjs';
 
 export async function readFile(filePath, encoding = 'utf8') {
   try {
-    return await fs.readFile(filePath, encoding);
+    return await fsPromises.readFile(filePath, encoding);
   } catch (err) {
     log.error(`Error reading file ${filePath}:`, err.message);
     throw err;
   }
 }
 
+export async function readFileStream(filePath, encoding = 'utf8') {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    const stream = fs.createReadStream(filePath, { encoding });
+    stream.on('data', (chunk) => {
+      data += chunk;
+    });
+    stream.on('end', () => resolve(data));
+    stream.on('error', (err) => {
+      log.error(`Error reading file ${filePath}:`, err.message);
+      reject(err);
+    });
+  });
+}
+
 export async function writeFile(filePath, data, encoding = 'utf8') {
   try {
-    await fs.writeFile(filePath, data, encoding);
+    await fsPromises.writeFile(filePath, data, encoding);
   } catch (err) {
     log.error(`Error writing file ${filePath}:`, err.message);
     throw err;
@@ -21,7 +37,7 @@ export async function writeFile(filePath, data, encoding = 'utf8') {
 
 export async function mkdir(dirPath, options = { recursive: true }) {
   try {
-    await fs.mkdir(dirPath, options);
+    await fsPromises.mkdir(dirPath, options);
   } catch (err) {
     log.error(`Error creating directory ${dirPath}:`, err.message);
     throw err;
@@ -30,7 +46,7 @@ export async function mkdir(dirPath, options = { recursive: true }) {
 
 export async function readdir(dirPath, options) {
   try {
-    return await fs.readdir(dirPath, options);
+    return await fsPromises.readdir(dirPath, options);
   } catch (err) {
     log.error(`Error reading directory ${dirPath}:`, err.message);
     throw err;
@@ -39,7 +55,7 @@ export async function readdir(dirPath, options) {
 
 export async function rename(oldPath, newPath) {
   try {
-    await fs.rename(oldPath, newPath);
+    await fsPromises.rename(oldPath, newPath);
   } catch (err) {
     log.error(
       `Error renaming file from ${oldPath} to ${newPath}:`,

--- a/test/build-insights.test.mjs
+++ b/test/build-insights.test.mjs
@@ -17,7 +17,7 @@ import { log } from '../scripts/utils/logger.mjs';
 
 // Mock file-utils before any imports
 vi.mock('../scripts/utils/file-utils.mjs', () => ({
-  readFile: vi.fn(),
+  readFileStream: vi.fn(),
   writeFile: vi.fn(),
   readdir: vi.fn(),
   mkdir: vi.fn(),
@@ -27,7 +27,13 @@ vi.mock('../scripts/utils/file-utils.mjs', () => ({
 // Import the module to be tested
 import * as buildInsights from '../scripts/build-insights.mjs';
 import { callOpenAI } from '../scripts/utils/llm-api.mjs';
-import { readFile, writeFile, readdir, mkdir, rename } from '../scripts/utils/file-utils.mjs'; // Import mocked file-utils functions
+import {
+  readFileStream,
+  writeFile,
+  readdir,
+  mkdir,
+  rename,
+} from '../scripts/utils/file-utils.mjs'; // Import mocked file-utils functions
 
 const originalArgv = process.argv.slice();
 
@@ -41,7 +47,7 @@ describe('build-insights.mjs', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    readFile.mockResolvedValue(mockMarkdownContent);
+    readFileStream.mockResolvedValue(mockMarkdownContent);
     writeFile.mockResolvedValue(undefined);
     readdir.mockImplementation((dirPath, options) => {
       if (dirPath === 'content' && options && options.withFileTypes) {

--- a/test/classify-inbox-errors.test.mjs
+++ b/test/classify-inbox-errors.test.mjs
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 
 vi.mock('fs/promises');
 vi.mock('../scripts/utils/llm-api.mjs', () => ({ callOpenAI: vi.fn() }));
+vi.mock('../scripts/utils/file-utils.mjs', () => ({ readFileStream: vi.fn() }));
 vi.mock('../scripts/utils/sanitize-markdown.mjs', () => ({
   sanitizeMarkdown: (s) => s,
 }));
@@ -13,10 +14,11 @@ import {
   getDynamicSections,
 } from '../scripts/classify-inbox.mjs';
 import { callOpenAI } from '../scripts/utils/llm-api.mjs';
+import { readFileStream } from '../scripts/utils/file-utils.mjs';
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  fs.readFile.mockResolvedValue('content');
+  readFileStream.mockResolvedValue('content');
   fs.writeFile.mockResolvedValue();
   fs.unlink.mockResolvedValue();
   fs.mkdir.mockResolvedValue();
@@ -32,7 +34,7 @@ afterEach(() => {
 
 describe('classify-inbox error paths', () => {
   it('classifyFile throws on read error', async () => {
-    fs.readFile.mockRejectedValueOnce(new Error('fail'));
+    readFileStream.mockRejectedValueOnce(new Error('fail'));
     await expect(classifyFile('x')).rejects.toThrow('fail');
   });
 

--- a/test/classify-inbox.test.mjs
+++ b/test/classify-inbox.test.mjs
@@ -7,10 +7,13 @@ vi.mock('fs/promises');
 vi.mock('../scripts/utils/llm-api.mjs', () => ({
   callOpenAI: vi.fn(),
 }));
+// Mock file-utils for readFileStream
+vi.mock('../scripts/utils/file-utils.mjs', () => ({ readFileStream: vi.fn() }));
 
 // Import the module to be tested
 import * as classifyInbox from '../scripts/classify-inbox.mjs';
 import { callOpenAI } from '../scripts/utils/llm-api.mjs';
+import { readFileStream } from '../scripts/utils/file-utils.mjs';
 
 describe('classify-inbox.mjs', () => {
   // Helper to create Dirent-like objects for mocking fs.readdir
@@ -60,7 +63,7 @@ describe('classify-inbox.mjs', () => {
         mockFiles.filter((d) => !d.isDirectory()).map((d) => d.name)
       );
     });
-    fs.readFile.mockResolvedValue('Test content');
+    readFileStream.mockResolvedValue('Test content');
     fs.mkdir.mockResolvedValue(undefined);
     fs.rename.mockResolvedValue(undefined);
     fs.writeFile.mockResolvedValue(undefined);

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -2,10 +2,13 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
+import fsSync from 'fs';
+import { Readable } from 'stream';
 import path from 'path';
 
 // Mock fs before any imports
 vi.mock('fs/promises');
+vi.mock('fs');
 
 // Mock external API calls
 vi.mock('../scripts/utils/github.mjs', () => ({
@@ -92,6 +95,10 @@ describe('Integration Test: Full Automation Pipeline', () => {
       'content/agents/test-agent.yml':
         'id: test-agent\nname: Test Agent\nowner: @testuser\nrole: Testing automation\nstatus: active\nlast_updated: 2025-01-01T00:00:00Z\ndescription: An agent for testing purposes.',
     };
+
+    vi.spyOn(fsSync, 'createReadStream').mockImplementation((filePath) => {
+      return Readable.from([fileContents[filePath] || '']);
+    });
 
     vi.spyOn(fs, 'readFile').mockImplementation((filePath) => {
       return Promise.resolve(fileContents[filePath] || '');


### PR DESCRIPTION
## Summary
- switch to `readFileStream` utility that uses `fs.createReadStream`
- refactor `classify-inbox.mjs` and `build-insights.mjs` to read files via streams
- adjust unit and integration tests for streaming file reads

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68705688ea54832a863057f6e6c5a432