### PR TITLE
Update script docs

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -9,7 +9,8 @@ All pages include example commands and sample output so you can reproduce the re
 | `fetch-gh-repos.mjs` | Fetches public repositories from GitHub and creates tool markdown files. | `GH_TOKEN`, optional `GH_USER`            |
 | `classify-inbox.mjs` | Uses OpenAI to categorise files dropped into `content/inbox`.            | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
 | `build-insights.mjs` | Summarises changed markdown files, validates the summary with `markdownlint`, and writes `.insight.md` outputs (failed files move to `content/insights-failed/`). | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
-| `build-rss.mjs` | Generates `public/rss.xml` from markdown metadata. | optional `BASE_URL` |
+| `build-search-index.mjs` | Builds `public/search-index.json` for site search. | none |
+| `build-rss.mjs` | Generates `public/rss.xml` from markdown metadata. | optional `BASE_URL` (defaults to `https://adrianwedd.github.io`) |
 | `agent-bus.mjs`      | Aggregates agent manifests and posts a summary issue on GitHub.          | `GH_TOKEN`, optional `GH_REPO`            |
 
 See the individual files below for further details.

--- a/docs/scripts/build-rss.md
+++ b/docs/scripts/build-rss.md
@@ -4,7 +4,11 @@ Generates an RSS 2.0 feed from all markdown files under `content/` and writes it
 
 This script walks the `content` directory recursively, reads front-matter using `gray-matter`, and sorts entries by their `date` field (or file modification time). The output RSS contains basic metadata like title, link, description and publication date.
 
-No required environment variables. Optionally set `BASE_URL` to override the root URL in the feed (defaults to `https://adrianwedd.github.io`). You can run the script manually with:
+## Environment Variables
+
+- `BASE_URL` – optional root URL for the feed. Defaults to `https://adrianwedd.github.io`.
+
+Run manually with:
 
 ```bash
 BASE_URL=https://example.com node scripts/build-rss.mjs

--- a/docs/scripts/build-search-index.md
+++ b/docs/scripts/build-search-index.md
@@ -1,0 +1,21 @@
+# build-search-index.mjs
+
+Creates a Lunr.js search index from markdown files under `content/` and writes it to `public/search-index.json`.
+
+The script walks the `content` directory recursively, reads front matter with `gray-matter`, and indexes each file's title and body for use in client-side search.
+
+## Environment Variables
+
+None.
+
+Run manually with:
+
+```bash
+node scripts/build-search-index.mjs
+```
+
+Example output:
+
+```text
+[INFO] Wrote public/search-index.json
+```


### PR DESCRIPTION
## Summary
- list `build-search-index` and `build-rss` in script index
- document search index script
- clarify optional `BASE_URL` default in the RSS guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68719bad3a70832ab909e13cb1528f0d