### PR TITLE
Add DNS validation script

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -12,5 +12,6 @@ All pages include example commands and sample output so you can reproduce the re
 | `build-search-index.mjs` | Builds `public/search-index.json` for site search. | none |
 | `build-rss.mjs` | Generates `public/rss.xml` from markdown metadata. | optional `BASE_URL` (defaults to `https://adrianwedd.github.io`) |
 | `agent-bus.mjs`      | Aggregates agent manifests and posts a summary issue on GitHub.          | `GH_TOKEN`, optional `GH_REPO`            |
+| `check-dns.mjs`      | Verifies A and CNAME records for the custom domain from `CNAME`. | none |
 
 See the individual files below for further details.

--- a/docs/scripts/check-dns.md
+++ b/docs/scripts/check-dns.md
@@ -1,0 +1,19 @@
+# check-dns.mjs
+
+Checks DNS records for the custom domain listed in the `CNAME` file. The script verifies that the domain resolves to GitHub Pages by looking for either the standard A records or a CNAME pointing to `*.github.io`.
+
+## Environment Variables
+
+None.
+
+Run manually with:
+
+```bash
+node scripts/check-dns.mjs
+```
+
+Example output:
+
+```text
+[INFO] DNS PASS for github.adrianwedd.com
+```

--- a/scripts/check-dns.mjs
+++ b/scripts/check-dns.mjs
@@ -1,0 +1,72 @@
+import fs from 'fs/promises';
+import { resolve4, resolveCname } from 'dns/promises';
+import { pathToFileURL } from 'url';
+import { log } from './utils/logger.mjs';
+
+const GITHUB_IPS = [
+  '185.199.108.153',
+  '185.199.109.153',
+  '185.199.110.153',
+  '185.199.111.153',
+];
+
+async function getDomain() {
+  const data = await fs.readFile('CNAME', 'utf8');
+  return data.trim();
+}
+
+async function lookupA(domain) {
+  try {
+    return await resolve4(domain);
+  } catch {
+    return [];
+  }
+}
+
+async function lookupCNAME(domain) {
+  try {
+    return await resolveCname(domain);
+  } catch {
+    return [];
+  }
+}
+
+function isGitHubA(records) {
+  return records.some((ip) => GITHUB_IPS.includes(ip));
+}
+
+function isGitHubCNAME(records) {
+  return records.some((cname) => cname.endsWith('.github.io'));
+}
+
+async function main() {
+  const domain = await getDomain();
+  const aRecords = await lookupA(domain);
+  const cnameRecords = await lookupCNAME(domain);
+
+  const ok = isGitHubA(aRecords) || isGitHubCNAME(cnameRecords);
+
+  if (ok) {
+    log.info(`DNS PASS for ${domain}`);
+  } else {
+    log.error(`DNS FAIL for ${domain}`);
+    if (aRecords.length) log.error('A records:', aRecords.join(', '));
+    if (cnameRecords.length) log.error('CNAME records:', cnameRecords.join(', '));
+  }
+}
+
+export {
+  getDomain,
+  lookupA,
+  lookupCNAME,
+  isGitHubA,
+  isGitHubCNAME,
+  main,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    log.error('check-dns main error:', err);
+    process.exit(1);
+  });
+}

--- a/test/check-dns.test.mjs
+++ b/test/check-dns.test.mjs
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+
+vi.mock('fs/promises');
+vi.mock('dns/promises', () => ({
+  resolve4: vi.fn(),
+  resolveCname: vi.fn(),
+}));
+
+import { main, isGitHubA, isGitHubCNAME } from '../scripts/check-dns.mjs';
+import { resolve4, resolveCname } from 'dns/promises';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('check-dns', () => {
+  it('isGitHubA detects GitHub IPs', () => {
+    expect(isGitHubA(['185.199.108.153'])).toBe(true);
+    expect(isGitHubA(['1.1.1.1'])).toBe(false);
+  });
+
+  it('isGitHubCNAME detects github.io', () => {
+    expect(isGitHubCNAME(['user.github.io'])).toBe(true);
+    expect(isGitHubCNAME(['example.com'])).toBe(false);
+  });
+
+  it('main logs pass when records match', async () => {
+    fs.readFile.mockResolvedValue('example.com');
+    resolve4.mockResolvedValue(['185.199.108.153']);
+    resolveCname.mockResolvedValue([]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await main();
+    expect(logSpy).toHaveBeenCalledWith('[INFO]', 'DNS PASS for example.com');
+  });
+
+  it('main logs fail when records do not match', async () => {
+    fs.readFile.mockResolvedValue('example.com');
+    resolve4.mockResolvedValue(['1.1.1.1']);
+    resolveCname.mockResolvedValue(['example.org']);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await main();
+    expect(errSpy).toHaveBeenCalledWith('[ERROR]', 'DNS FAIL for example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add `check-dns.mjs` to verify custom domain records
- document the new script and update scripts overview
- test DNS helper logic with Vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871cff49afc832a8774da026f538112