### PR TITLE
Fix lint errors for stable CI

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
 };

--- a/scripts/build-insights.mjs
+++ b/scripts/build-insights.mjs
@@ -1,11 +1,16 @@
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { log } from './utils/logger.mjs';
-import { readFileStream, writeFile, readdir, mkdir, rename } from './utils/file-utils.mjs';
+import {
+  readFileStream,
+  writeFile,
+  readdir,
+  mkdir,
+  rename,
+} from './utils/file-utils.mjs';
 import { callOpenAI } from './utils/llm-api.mjs';
 import { lint } from 'markdownlint/promise';
 import { sanitizeMarkdown } from './utils/sanitize-markdown.mjs';
-
 
 // Discover which content subdirectories contain notes to summarise
 async function getTargetDirs() {
@@ -86,7 +91,6 @@ async function main() {
   }
 
   const TARGET_DIRS = await getTargetDirs();
-  const RESOLVED_TARGET_DIRS = TARGET_DIRS.map((dir) => path.resolve(dir));
 
   // Get files to process from arguments or read from target directories
   let filesToProcess = [];

--- a/scripts/check-dns.mjs
+++ b/scripts/check-dns.mjs
@@ -51,18 +51,12 @@ async function main() {
   } else {
     log.error(`DNS FAIL for ${domain}`);
     if (aRecords.length) log.error('A records:', aRecords.join(', '));
-    if (cnameRecords.length) log.error('CNAME records:', cnameRecords.join(', '));
+    if (cnameRecords.length)
+      log.error('CNAME records:', cnameRecords.join(', '));
   }
 }
 
-export {
-  getDomain,
-  lookupA,
-  lookupCNAME,
-  isGitHubA,
-  isGitHubCNAME,
-  main,
-};
+export { getDomain, lookupA, lookupCNAME, isGitHubA, isGitHubCNAME, main };
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((err) => {

--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -99,7 +99,9 @@ async function moveFile(src, destDir, tags = []) {
     log.error(`Error writing file to ${dest}:`, err.message);
     try {
       await fs.unlink(dest);
-    } catch {}
+    } catch (cleanupErr) {
+      log.warn(`Cleanup failed for ${dest}:`, cleanupErr.message);
+    }
     throw err;
   }
 
@@ -109,7 +111,9 @@ async function moveFile(src, destDir, tags = []) {
     log.error(`Error removing original file ${src}:`, err.message);
     try {
       await fs.unlink(dest);
-    } catch {}
+    } catch (cleanupErr) {
+      log.warn(`Cleanup failed for ${dest}:`, cleanupErr.message);
+    }
     throw err;
   }
 

--- a/scripts/utils/sanitize-markdown.mjs
+++ b/scripts/utils/sanitize-markdown.mjs
@@ -9,4 +9,3 @@ const DOMPurify = createDOMPurify(window);
 export function sanitizeMarkdown(text) {
   return DOMPurify.sanitize(text);
 }
-

--- a/tasks.yml
+++ b/tasks.yml
@@ -1085,7 +1085,7 @@ phases:
 
   - id: 57
     title: 'Enhance the `CONTRIBUTING.md` Guide'
-    description: 'Enhance the `CONTRIBUTING.md` guide with more detailed information on the project\'s branching strategy, commit message format, and code style guidelines.'
+    description: "Enhance the `CONTRIBUTING.md` guide with more detailed information on the project's branching strategy, commit message format, and code style guidelines."
     component: 'Documentation'
     dependencies: [45]
     priority: 2
@@ -1212,7 +1212,7 @@ phases:
     actionable_steps:
       - 'Add entries for `build-search-index.mjs` and `build-rss.mjs` to the table in `docs/scripts/README.md`.'
       - 'Create `docs/scripts/build-search-index.md` and `docs/scripts/build-rss.md`.'
-      - 'In each script\'s documentation, add a section for environment variables that lists the default values for optional variables.'
+      - "In each script's documentation, add a section for environment variables that lists the default values for optional variables."
     acceptance_criteria:
       - 'All automation scripts are fully documented.'
       - 'The documentation is consistent and up-to-date.'

--- a/test/e2e/pipeline.test.mjs
+++ b/test/e2e/pipeline.test.mjs
@@ -57,7 +57,11 @@ describe('E2E: classify inbox then build insights', () => {
     callOpenAI.mockImplementation((prompt) => {
       if (prompt.includes('garden note')) {
         return Promise.resolve(
-          JSON.stringify({ section: 'garden', tags: ['plants'], confidence: 0.9 })
+          JSON.stringify({
+            section: 'garden',
+            tags: ['plants'],
+            confidence: 0.9,
+          })
         );
       }
       if (prompt.includes('Log entry')) {

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -53,11 +53,19 @@ describe('Integration Test: Full Automation Pipeline', () => {
 
     const utils = await import('../scripts/utils/github.mjs');
     githubFetch = vi.fn();
-    vi.spyOn(utils, 'githubFetch').mockImplementation((...args) => githubFetch(...args));
+    vi.spyOn(utils, 'githubFetch').mockImplementation((...args) =>
+      githubFetch(...args)
+    );
 
-    ({ main: fetchGhReposMain } = await import('../scripts/fetch-gh-repos.mjs'));
-    ({ main: classifyInboxMain, callOpenAI } = await import('../scripts/classify-inbox.mjs'));
-    ({ main: buildInsightsMain } = await import('../scripts/build-insights.mjs'));
+    ({ main: fetchGhReposMain } = await import(
+      '../scripts/fetch-gh-repos.mjs'
+    ));
+    ({ main: classifyInboxMain, callOpenAI } = await import(
+      '../scripts/classify-inbox.mjs'
+    ));
+    ({ main: buildInsightsMain } = await import(
+      '../scripts/build-insights.mjs'
+    ));
     ({ main: agentBusMain } = await import('../scripts/agent-bus.mjs'));
 
     // Mock fs operations for the entire pipeline


### PR DESCRIPTION
## Summary
- clean up commitlint config trailing comma
- handle cleanup errors in `classify-inbox.mjs`
- drop unused variable from `build-insights.mjs`
- apply prettier fixes to scripts and tests
- correct quoting in `tasks.yml`

## Testing
- `npm test`
- `npm run lint`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_6871d4a45a64832a84c77d17baea548d