### PR TITLE
Fix OSSAR ESLint run

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -27,6 +27,15 @@ jobs:
       - run: git checkout HEAD^2
         if: ${{ github.event_name == 'pull_request' }}
 
+      # OSSAR's ESLint configuration only targets `.js` or `.ts` files. Our
+      # Node scripts use the `.mjs` extension, so we temporarily duplicate them
+      # with a `.js` suffix to ensure they are linted during the scan.
+      - name: Duplicate .mjs files for OSSAR
+        run: |
+          for f in scripts/*.mjs; do
+            cp "$f" "${f%.mjs}.js"
+          done
+
       # Ensure a compatible version of dotnet is installed.
       # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
       # A version greater than or equal to v3.1.201 of dotnet must be installed on the agent in order to run this action.


### PR DESCRIPTION
## Summary
- adjust ossar-analysis.yml so the action can lint `.mjs` files by duplicating them as `.js`

This tweak keeps the security scan passing, aligning with the "Process Hardening" phase that requires successful checks.

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687215b744c4832abc7b21c4e7e169cd