### PR TITLE
Improve DNS script logging

### DIFF
--- a/scripts/check-dns.mjs
+++ b/scripts/check-dns.mjs
@@ -10,9 +10,19 @@ const GITHUB_IPS = [
   '185.199.111.153',
 ];
 
+// Read the domain from the CNAME file. Returns null if the file does not exist.
 async function getDomain() {
-  const data = await fs.readFile('CNAME', 'utf8');
-  return data.trim();
+  try {
+    const data = await fs.readFile('CNAME', 'utf8');
+    return data.trim();
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      log.error('CNAME file missing; DNS check skipped');
+    } else {
+      log.error('Error reading CNAME file:', err.message);
+    }
+    return null;
+  }
 }
 
 async function lookupA(domain) {
@@ -41,6 +51,7 @@ function isGitHubCNAME(records) {
 
 async function main() {
   const domain = await getDomain();
+  if (!domain) return;
   const aRecords = await lookupA(domain);
   const cnameRecords = await lookupCNAME(domain);
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -971,6 +971,7 @@ phases:
       - 'Analyze workflow logs from failed runs to identify specific error messages and failing steps.'
       - 'Replicate failures locally where possible by running the scripts with the same inputs and environment variables.'
       - 'Add more detailed logging to scripts to trace execution flow and variable states.'
+      - 'Improve check-dns.mjs to log when the CNAME file is missing.'
       - 'Create isolated test cases that specifically target the failing conditions.'
       - 'Incrementally apply fixes and re-run the workflow to verify the solution.'
     acceptance_criteria:

--- a/test/check-dns.test.mjs
+++ b/test/check-dns.test.mjs
@@ -46,4 +46,11 @@ describe('check-dns', () => {
     await main();
     expect(errSpy).toHaveBeenCalledWith('[ERROR]', 'DNS FAIL for example.com');
   });
+
+  it('main logs error when CNAME file missing', async () => {
+    fs.readFile.mockRejectedValue(Object.assign(new Error('no file'), { code: 'ENOENT' }));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await main();
+    expect(errSpy).toHaveBeenCalledWith('[ERROR]', 'CNAME file missing; DNS check skipped');
+  });
 });


### PR DESCRIPTION
## Summary
- handle missing CNAME file in `check-dns.mjs`
- add regression test for CNAME missing case
- document the logging improvement in `tasks.yml`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687276bc842c832a8741413a8565e547