### PR TITLE
refactor: replace readFileStream with readFile

### DIFF
--- a/scripts/build-insights.mjs
+++ b/scripts/build-insights.mjs
@@ -2,7 +2,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { log } from './utils/logger.mjs';
 import {
-  readFileStream,
+  readFile,
   writeFile,
   readdir,
   mkdir,
@@ -60,7 +60,7 @@ async function moveToFailed(srcPath) {
 
 // Generate an insight markdown file next to the source markdown
 async function processMarkdownFile(filePath) {
-  const content = await readFileStream(filePath);
+  const content = await readFile(filePath);
   const fileName = path.basename(filePath);
   const dirName = path.dirname(filePath);
 

--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { readFileStream } from './utils/file-utils.mjs';
+import { readFile } from './utils/file-utils.mjs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { callOpenAI } from './utils/llm-api.mjs';
@@ -37,7 +37,7 @@ async function buildPrompt(content) {
 async function classifyFile(filePath) {
   let content;
   try {
-    content = await readFileStream(filePath);
+    content = await readFile(filePath);
   } catch (err) {
     log.error(
       `Error reading file ${filePath} for classification:`,
@@ -84,7 +84,7 @@ async function moveFile(src, destDir, tags = []) {
   const dest = path.join(destDir, path.basename(src));
   let data;
   try {
-    data = await readFileStream(src);
+    data = await readFile(src);
   } catch (err) {
     log.error(`Error reading file ${src}:`, err.message);
     throw err;

--- a/tasks.yml
+++ b/tasks.yml
@@ -1245,7 +1245,7 @@ phases:
     component: 'Documentation'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     command: null
     task_id: 'PIN-NEW-65'
     area: 'Architecture'
@@ -1262,7 +1262,7 @@ phases:
     component: 'Automation Scripts'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     command: null
     task_id: 'PIN-NEW-66'
     area: 'Optimization'

--- a/test/build-insights.test.mjs
+++ b/test/build-insights.test.mjs
@@ -17,7 +17,7 @@ import { log } from '../scripts/utils/logger.mjs';
 
 // Mock file-utils before any imports
 vi.mock('../scripts/utils/file-utils.mjs', () => ({
-  readFileStream: vi.fn(),
+  readFile: vi.fn(),
   writeFile: vi.fn(),
   readdir: vi.fn(),
   mkdir: vi.fn(),
@@ -28,7 +28,7 @@ vi.mock('../scripts/utils/file-utils.mjs', () => ({
 import * as buildInsights from '../scripts/build-insights.mjs';
 import { callOpenAI } from '../scripts/utils/llm-api.mjs';
 import {
-  readFileStream,
+  readFile,
   writeFile,
   readdir,
   mkdir,
@@ -47,7 +47,7 @@ describe('build-insights.mjs', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    readFileStream.mockResolvedValue(mockMarkdownContent);
+    readFile.mockResolvedValue(mockMarkdownContent);
     writeFile.mockResolvedValue(undefined);
     readdir.mockImplementation((dirPath, options) => {
       if (dirPath === 'content' && options && options.withFileTypes) {

--- a/test/classify-inbox-errors.test.mjs
+++ b/test/classify-inbox-errors.test.mjs
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 
 vi.mock('fs/promises');
 vi.mock('../scripts/utils/llm-api.mjs', () => ({ callOpenAI: vi.fn() }));
-vi.mock('../scripts/utils/file-utils.mjs', () => ({ readFileStream: vi.fn() }));
+vi.mock('../scripts/utils/file-utils.mjs', () => ({ readFile: vi.fn() }));
 vi.mock('../scripts/utils/sanitize-markdown.mjs', () => ({
   sanitizeMarkdown: (s) => s,
 }));
@@ -14,11 +14,11 @@ import {
   getDynamicSections,
 } from '../scripts/classify-inbox.mjs';
 import { callOpenAI } from '../scripts/utils/llm-api.mjs';
-import { readFileStream } from '../scripts/utils/file-utils.mjs';
+import { readFile } from '../scripts/utils/file-utils.mjs';
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  readFileStream.mockResolvedValue('content');
+  readFile.mockResolvedValue('content');
   fs.writeFile.mockResolvedValue();
   fs.unlink.mockResolvedValue();
   fs.mkdir.mockResolvedValue();
@@ -34,7 +34,7 @@ afterEach(() => {
 
 describe('classify-inbox error paths', () => {
   it('classifyFile throws on read error', async () => {
-    readFileStream.mockRejectedValueOnce(new Error('fail'));
+    readFile.mockRejectedValueOnce(new Error('fail'));
     await expect(classifyFile('x')).rejects.toThrow('fail');
   });
 

--- a/test/classify-inbox.test.mjs
+++ b/test/classify-inbox.test.mjs
@@ -7,13 +7,13 @@ vi.mock('fs/promises');
 vi.mock('../scripts/utils/llm-api.mjs', () => ({
   callOpenAI: vi.fn(),
 }));
-// Mock file-utils for readFileStream
-vi.mock('../scripts/utils/file-utils.mjs', () => ({ readFileStream: vi.fn() }));
+// Mock file-utils for readFile
+vi.mock('../scripts/utils/file-utils.mjs', () => ({ readFile: vi.fn() }));
 
 // Import the module to be tested
 import * as classifyInbox from '../scripts/classify-inbox.mjs';
 import { callOpenAI } from '../scripts/utils/llm-api.mjs';
-import { readFileStream } from '../scripts/utils/file-utils.mjs';
+import { readFile } from '../scripts/utils/file-utils.mjs';
 
 describe('classify-inbox.mjs', () => {
   // Helper to create Dirent-like objects for mocking fs.readdir
@@ -63,7 +63,7 @@ describe('classify-inbox.mjs', () => {
         mockFiles.filter((d) => !d.isDirectory()).map((d) => d.name)
       );
     });
-    readFileStream.mockResolvedValue('Test content');
+    readFile.mockResolvedValue('Test content');
     fs.mkdir.mockResolvedValue(undefined);
     fs.rename.mockResolvedValue(undefined);
     fs.writeFile.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- replace `readFileStream` with simpler `readFile` calls
- update tests to mock `readFile`
- mark optimization task as done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872ddefd638832a9342f5f79066844d