### PR TITLE
Refine deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,12 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v46
 
+      - name: Get changed content
+        id: changed-content
+        uses: tj-actions/changed-files@v46
+        with:
+          files: content/**
+
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -94,8 +100,10 @@ jobs:
           node scripts/classify-inbox.mjs ${{ steps.changed-files.outputs.all_changed_files }}
           node scripts/build-insights.mjs ${{ steps.changed-files.outputs.all_changed_files }}
           node scripts/agent-bus.mjs
-          node scripts/build-search-index.mjs
-          node scripts/build-rss.mjs
+          if [ "${{ steps.changed-content.outputs.any_changed }}" = 'true' ]; then
+            node scripts/build-search-index.mjs
+            node scripts/build-rss.mjs
+          fi
 
       - name: Build with Astro
         run: |

--- a/tasks.yml
+++ b/tasks.yml
@@ -1434,7 +1434,7 @@ phases:
     component: 'CI/CD'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-72'


### PR DESCRIPTION
## Summary
- rebuild RSS feed and search index only when content changes
- update tasks to mark workflow efficiency completed

## Testing
- `npm test`
- `yamllint tasks.yml`
- `python scripts/validate-tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_6872eb18873c832a8add9bef60fa71d1