### PR TITLE
Fix ESLint config for OSSAR

### DIFF
--- a/.github/ossar/.gdnconfig
+++ b/.github/ossar/.gdnconfig
@@ -1,0 +1,7 @@
+{
+  "tools": {
+    "eslint": {
+      "arguments": "--ext .js,.mjs,.cjs"
+    }
+  }
+}

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -27,14 +27,9 @@ jobs:
       - run: git checkout HEAD^2
         if: ${{ github.event_name == 'pull_request' }}
 
-      # OSSAR's ESLint configuration only targets `.js` or `.ts` files. Our
-      # Node scripts use the `.mjs` extension, so we temporarily duplicate them
-      # with a `.js` suffix to ensure they are linted during the scan.
-      - name: Duplicate .mjs files for OSSAR
-        run: |
-          for f in scripts/*.mjs; do
-            cp "$f" "${f%.mjs}.js"
-          done
+
+      # Use a custom configuration so ESLint scans `.mjs` files directly.
+      # The `.gdnconfig` file specifies the extension list for OSSAR's ESLint run.
 
       # Ensure a compatible version of dotnet is installed.
       # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
@@ -49,6 +44,8 @@ jobs:
       - name: Run OSSAR
         uses: github/ossar-action@v1
         id: ossar
+        with:
+          config: .github/ossar/.gdnconfig
 
         # Upload results to the Security tab
       - name: Upload OSSAR results

--- a/tasks.yml
+++ b/tasks.yml
@@ -1452,7 +1452,7 @@ phases:
     component: 'CI/CD'
     dependencies: []
     priority: 2
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-73'


### PR DESCRIPTION
## Summary
- lint `.mjs` files directly with OSSAR
- add OSSAR config file
- mark task 73 as done

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872eddfa90c832a85b0519094cfce59