### PR TITLE
Centralise script directory constants

### DIFF
--- a/scripts/agent-bus.mjs
+++ b/scripts/agent-bus.mjs
@@ -4,10 +4,11 @@ import { pathToFileURL } from 'url';
 import { parse } from 'yaml';
 import { githubFetch } from './utils/github.mjs'; // Import the new utility
 import { log } from './utils/logger.mjs';
+import { AGENTS_DIR } from './utils/constants.mjs';
 
 // Read YAML manifest files from the given directory
 // Returns an array of parsed manifest objects
-async function loadManifests(dir = path.join('content', 'agents')) {
+async function loadManifests(dir = AGENTS_DIR) {
   let files = [];
   try {
     files = await fs.readdir(dir);

--- a/scripts/build-insights.mjs
+++ b/scripts/build-insights.mjs
@@ -2,6 +2,10 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { log } from './utils/logger.mjs';
 import {
+  CONTENT_DIR,
+  INSIGHTS_FAILED_DIR,
+} from './utils/constants.mjs';
+import {
   readFile,
   writeFile,
   readdir,
@@ -14,7 +18,7 @@ import { sanitizeMarkdown } from './utils/sanitize-markdown.mjs';
 
 // Discover which content subdirectories contain notes to summarise
 async function getTargetDirs() {
-  const contentDir = 'content';
+  const contentDir = CONTENT_DIR;
   try {
     const entries = await readdir(contentDir, { withFileTypes: true });
     return entries
@@ -47,7 +51,7 @@ async function validateMarkdown(text, filePath = '') {
 
 // Move an input file to the failure directory if processing fails
 async function moveToFailed(srcPath) {
-  const failedDir = path.join('content', 'insights-failed');
+  const failedDir = INSIGHTS_FAILED_DIR;
   try {
     await mkdir(failedDir, { recursive: true });
     const dest = path.join(failedDir, path.basename(srcPath));

--- a/scripts/build-rss.mjs
+++ b/scripts/build-rss.mjs
@@ -3,6 +3,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import matter from 'gray-matter';
 import { log } from './utils/logger.mjs';
+import { CONTENT_DIR, PUBLIC_DIR } from './utils/constants.mjs';
 
 const BASE_URL = process.env.BASE_URL || 'https://adrianwedd.github.io';
 
@@ -23,7 +24,7 @@ async function collectMarkdown(dir) {
 
 // Convert a markdown file path in content/ to a URL slug
 function slugify(filePath) {
-  const relative = filePath.replace(/^content\//, '');
+  const relative = filePath.replace(new RegExp(`^${CONTENT_DIR}/`), '');
   return '/' + relative.replace(/\.md$/, '') + '/';
 }
 
@@ -58,7 +59,7 @@ function buildXml(items) {
 
 // Generate rss.xml in the public directory
 async function main() {
-  const files = await collectMarkdown('content');
+  const files = await collectMarkdown(CONTENT_DIR);
   const items = [];
   for (const file of files) {
     const raw = await fs.readFile(file, 'utf8');
@@ -71,9 +72,9 @@ async function main() {
   }
   items.sort((a, b) => b.date - a.date);
   const xml = buildXml(items);
-  await fs.mkdir('public', { recursive: true });
-  await fs.writeFile('public/rss.xml', xml);
-  log.info('Wrote public/rss.xml');
+  await fs.mkdir(PUBLIC_DIR, { recursive: true });
+  await fs.writeFile(path.join(PUBLIC_DIR, 'rss.xml'), xml);
+  log.info(`Wrote ${path.join(PUBLIC_DIR, 'rss.xml')}`);
 }
 
 export { collectMarkdown, slugify, buildXml, main };

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'url';
 import lunr from 'lunr';
 import matter from 'gray-matter';
 import { log } from './utils/logger.mjs';
+import { CONTENT_DIR, PUBLIC_DIR } from './utils/constants.mjs';
 
 // Recursively collect all markdown files for indexing
 async function collectMarkdown(dir) {
@@ -22,13 +23,13 @@ async function collectMarkdown(dir) {
 
 // Convert a markdown path into a site-relative URL
 function slugify(filePath) {
-  const relative = filePath.replace(/^content\//, '');
+  const relative = filePath.replace(new RegExp(`^${CONTENT_DIR}/`), '');
   return '/' + relative.replace(/\.md$/, '') + '/';
 }
 
 // Build lunr.js index and write to public/search-index.json
 async function main() {
-  const files = await collectMarkdown('content');
+  const files = await collectMarkdown(CONTENT_DIR);
   const docs = [];
   for (const file of files) {
     const raw = await fs.readFile(file, 'utf8');
@@ -48,9 +49,12 @@ async function main() {
   });
 
   const output = { index: idx.toJSON(), docs };
-  await fs.mkdir('public', { recursive: true });
-  await fs.writeFile('public/search-index.json', JSON.stringify(output));
-  log.info('Wrote public/search-index.json');
+  await fs.mkdir(PUBLIC_DIR, { recursive: true });
+  await fs.writeFile(
+    path.join(PUBLIC_DIR, 'search-index.json'),
+    JSON.stringify(output)
+  );
+  log.info(`Wrote ${path.join(PUBLIC_DIR, 'search-index.json')}`);
 }
 
 export { collectMarkdown, slugify, main };

--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -5,10 +5,16 @@ import { pathToFileURL } from 'url';
 import { callOpenAI } from './utils/llm-api.mjs';
 import { log } from './utils/logger.mjs';
 import { sanitizeMarkdown } from './utils/sanitize-markdown.mjs';
+import {
+  CONTENT_DIR,
+  INBOX_DIR,
+  INBOX_FAILED_DIR,
+  UNTAGGED_DIR,
+} from './utils/constants.mjs';
 
 // Discover valid content sections for classification
 async function getDynamicSections() {
-  const contentDir = path.join('content');
+  const contentDir = CONTENT_DIR;
   try {
     const entries = await fs.readdir(contentDir, { withFileTypes: true });
     const sections = entries
@@ -127,8 +133,8 @@ async function main() {
     return;
   }
 
-  const inboxDir = path.join('content', 'inbox');
-  const failedDir = path.join(inboxDir, 'failed');
+  const inboxDir = INBOX_DIR;
+  const failedDir = INBOX_FAILED_DIR;
 
   const dynamicSections = await getDynamicSections(); // Get dynamic sections for validation
   log.debug(`Available sections: ${dynamicSections.join(', ')}`);
@@ -208,12 +214,12 @@ async function main() {
         dynamicSections.includes(result.section) &&
         result.confidence >= 0.8
       ) {
-        targetDir = path.join('content', result.section);
+        targetDir = path.join(CONTENT_DIR, result.section);
         if (result.tags && result.tags.length) {
           tags = result.tags;
         }
       } else {
-        targetDir = path.join('content', 'untagged');
+        targetDir = UNTAGGED_DIR;
       }
 
       const dest = await moveFile(filePath, targetDir, tags);

--- a/scripts/fetch-gh-repos.mjs
+++ b/scripts/fetch-gh-repos.mjs
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'url';
 import { githubFetch } from './utils/github.mjs'; // Import the new utility
 import { log } from './utils/logger.mjs';
 import { mkdir, writeFile } from './utils/file-utils.mjs';
+import { CONTENT_DIR, TOOLS_DIR } from './utils/constants.mjs';
 
 // Determine the GitHub username for the current token
 async function getLogin() {
@@ -48,7 +49,7 @@ async function main() {
     (r) => Array.isArray(r.topics) && r.topics.includes('tool')
   );
 
-  const dir = path.join('content', 'tools');
+  const dir = TOOLS_DIR;
   try {
     await mkdir(dir, { recursive: true });
   } catch (err) {

--- a/scripts/utils/constants.mjs
+++ b/scripts/utils/constants.mjs
@@ -1,0 +1,11 @@
+import path from 'path';
+
+export const CONTENT_DIR = 'content';
+export const PUBLIC_DIR = 'public';
+
+export const INBOX_DIR = path.join(CONTENT_DIR, 'inbox');
+export const INBOX_FAILED_DIR = path.join(INBOX_DIR, 'failed');
+export const UNTAGGED_DIR = path.join(CONTENT_DIR, 'untagged');
+export const TOOLS_DIR = path.join(CONTENT_DIR, 'tools');
+export const AGENTS_DIR = path.join(CONTENT_DIR, 'agents');
+export const INSIGHTS_FAILED_DIR = path.join(CONTENT_DIR, 'insights-failed');


### PR DESCRIPTION
## Summary
- add `scripts/utils/constants.mjs` with shared paths
- refactor scripts to import constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872ef514a28832a919000bfc3a72354