### PR TITLE
Add doc links for search index and RSS scripts

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -15,3 +15,6 @@ All pages include example commands and sample output so you can reproduce the re
 | `check-dns.mjs`      | Verifies A and CNAME records for the custom domain from `CNAME`. | none |
 
 See the individual files below for further details.
+
+- [build-search-index.mjs](build-search-index.md) – builds `public/search-index.json` for Lunr search.
+- [build-rss.mjs](build-rss.md) – generates the site's RSS feed.


### PR DESCRIPTION
## Summary
- document how to build the search index and RSS feed in the script docs index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687301315b0c832aa15af5fe055a4e70