### PR TITLE
Improve script concurrency

### DIFF
--- a/scripts/build-insights.mjs
+++ b/scripts/build-insights.mjs
@@ -148,9 +148,12 @@ async function main() {
     }
   }
 
-  for (const filePath of filesToProcess) {
-    await processMarkdownFile(filePath);
-  }
+  const tasks = filesToProcess.map((filePath) =>
+    processMarkdownFile(filePath).catch((err) => {
+      log.error(`Error processing ${filePath}:`, err.message);
+    })
+  );
+  await Promise.all(tasks);
   log.info('Insight generation complete.');
 }
 

--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -188,7 +188,7 @@ async function main() {
     }
   }
 
-  for (const name of filesToProcess) {
+  const tasks = filesToProcess.map(async (name) => {
     const filePath = path.join(inboxDir, name);
     const lockPath = `${filePath}.lock`;
 
@@ -200,7 +200,7 @@ async function main() {
       } else {
         log.error(`Unable to create lock file ${lockPath}:`, err.message);
       }
-      continue;
+      return;
     }
 
     log.info(`Processing ${name}`);
@@ -209,7 +209,6 @@ async function main() {
 
     try {
       const result = await classifyFile(filePath);
-      // Use dynamicSections for validation
       if (
         dynamicSections.includes(result.section) &&
         result.confidence >= 0.8
@@ -235,7 +234,9 @@ async function main() {
         log.error(`Error removing lock file ${lockPath}:`, err.message);
       }
     }
-  }
+  });
+
+  await Promise.all(tasks);
 }
 
 export {

--- a/tasks.yml
+++ b/tasks.yml
@@ -1632,7 +1632,7 @@ phases:
     component: 'Performance'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-83'


### PR DESCRIPTION
## Summary
- process files concurrently in `build-insights.mjs`
- process files concurrently in `classify-inbox.mjs`
- mark the parallelisation task as done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687314467924832a871c6ebd2a21bc69