### PR TITLE
Add frontmatter schema

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,25 @@
+import { defineCollection, z } from 'astro:content';
+
+const baseSchema = z.object({
+  title: z.string(),
+  date: z.coerce.date(),
+  tags: z.array(z.string()).default([]),
+  description: z.string(),
+  status: z.enum(['draft', 'published', 'archived']).default('draft'),
+});
+
+const garden = defineCollection({ type: 'content', schema: baseSchema });
+const codex = defineCollection({ type: 'content', schema: baseSchema });
+const logs = defineCollection({ type: 'content', schema: baseSchema });
+const mirror = defineCollection({ type: 'content', schema: baseSchema });
+const tools = defineCollection({ type: 'content', schema: baseSchema });
+const resume = defineCollection({ type: 'content', schema: baseSchema });
+
+export const collections = {
+  garden,
+  codex,
+  logs,
+  mirror,
+  tools,
+  resume,
+};

--- a/tasks.yml
+++ b/tasks.yml
@@ -1668,7 +1668,7 @@ phases:
     component: 'Architecture'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-85'


### PR DESCRIPTION
## Summary
- validate markdown frontmatter using Astro Content Collections
- mark task PIN-NEW-85 as done

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68731b4e0750832a83957dc16adce807