### PR TITLE
Improve insight error logging

### DIFF
--- a/scripts/build-insights.mjs
+++ b/scripts/build-insights.mjs
@@ -69,7 +69,7 @@ async function processMarkdownFile(filePath) {
     const summary = await callOpenAI(buildSummaryPrompt(content));
     const isValid = await validateMarkdown(summary, filePath);
     if (!isValid) {
-      log.error(`Invalid markdown summary for ${fileName}`);
+      log.error(`Invalid markdown summary for ${filePath}`);
       await moveToFailed(filePath);
       return;
     }

--- a/tasks.yml
+++ b/tasks.yml
@@ -1686,7 +1686,7 @@ phases:
     component: 'Robustness'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-86'


### PR DESCRIPTION
## Summary
- log full file path when markdown summary fails in `build-insights.mjs`
- mark task `PIN-NEW-86` as complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68731de97180832ab87f5aca76cf47e8