### PR TITLE
chore: enforce pnpm via preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "preinstall": "npx only-allow pnpm",
     "test": "vitest run --coverage",
     "lint": "eslint . --ext .js,.mjs,.cjs,.ts",
     "format": "prettier --write .",

--- a/tasks.yml
+++ b/tasks.yml
@@ -1722,7 +1722,7 @@ phases:
     component: 'Tooling'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-88'


### PR DESCRIPTION
## Summary
- enforce pnpm usage by adding a `preinstall` script
- mark task 88 as done in `tasks.yml`

## Testing
- `node --version` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873204977d4832abed667a32e94324b