### PR TITLE
Remove carets from core dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@vitest/coverage-v8": "^3.2.4",
-        "astro": "^5.11.0",
-        "eslint": "^8.57.1",
+        "astro": "5.11.0",
+        "eslint": "8.57.1",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.5.1",
         "husky": "^9.1.7",
@@ -29,7 +29,7 @@
         "prettier": "^3.6.2",
         "rehype-external-links": "^3.0.0",
         "sharp": "^0.34.3",
-        "vitest": "^3.2.4"
+        "vitest": "3.2.4"
       }
     },
     "node_modules/@altano/tiny-async-pool": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@vitest/coverage-v8": "^3.2.4",
-    "astro": "^5.11.0",
-    "eslint": "^8.57.1",
+    "astro": "5.11.0",
+    "eslint": "8.57.1",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.1",
     "husky": "^9.1.7",
@@ -25,7 +25,7 @@
     "prettier": "^3.6.2",
     "rehype-external-links": "^3.0.0",
     "sharp": "^0.34.3",
-    "vitest": "^3.2.4"
+    "vitest": "3.2.4"
   },
   "dependencies": {
     "dompurify": "^3.0.3",

--- a/tasks.yml
+++ b/tasks.yml
@@ -1740,7 +1740,7 @@ phases:
     component: 'Dependency Management'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-89'


### PR DESCRIPTION
## Summary
- pin `astro`, `vitest` and `eslint` versions
- mark dependency pinning task complete

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873212674b0832a9e09bd458f0483e4