### PR TITLE
Enable strict TypeScript checks

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -1758,7 +1758,7 @@ phases:
     component: 'Type Safety'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-90'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true
+  }
+}


### PR DESCRIPTION
## Summary
- enable `noUnusedLocals`, `noUnusedParameters`, and `exactOptionalPropertyTypes`
- mark TypeScript strictness task done in `tasks.yml`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687323356ad0832abc7e98f9208e9a5e