### PR TITLE
Centralize path aliases

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import rehypeExternalLinks from 'rehype-external-links';
 import image from '@astrojs/image';
+import alias from './paths.js';
 
 export default defineConfig({
   site: 'https://github.adrianwedd.com',
@@ -15,5 +16,10 @@ export default defineConfig({
         },
       ],
     ],
+  },
+  vite: {
+    resolve: {
+      alias,
+    },
   },
 });

--- a/paths.js
+++ b/paths.js
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+const alias = {
+  '@': resolve(root, 'src'),
+  '@scripts': resolve(root, 'scripts'),
+  '@content': resolve(root, 'content'),
+};
+
+export default alias;

--- a/tasks.yml
+++ b/tasks.yml
@@ -1776,7 +1776,7 @@ phases:
     component: 'Developer Experience'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-91'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,12 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@scripts/*": ["scripts/*"],
+      "@content/*": ["content/*"]
+    }
   }
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import alias from './paths.js';
 
 export default defineConfig({
+  resolve: { alias },
   test: {
     environment: 'node',
     include: ['test/**/*.test.{ts,js,mjs,cjs}'], // Include all test files


### PR DESCRIPTION
## Summary
- add a `paths.js` helper exporting alias mappings
- use shared aliases in `astro.config.mjs` and `vitest.config.mjs`
- configure TypeScript `paths` to match
- mark task 91 as done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873259c7af4832a92082c8a926d4fae