### PR TITLE
Add article wrapper for posts

### DIFF
--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,0 +1,10 @@
+---
+import BaseLayout from '../../layouts/Base.astro';
+const { slug } = Astro.params;
+---
+<BaseLayout>
+  <article class="prose mx-auto p-4">
+    <h1 class="text-xl font-bold">{slug}</h1>
+    <slot />
+  </article>
+</BaseLayout>

--- a/tasks.yml
+++ b/tasks.yml
@@ -1812,7 +1812,7 @@ phases:
     component: 'Accessibility'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-93'


### PR DESCRIPTION
## Summary
- add a dynamic posts route
- wrap post content in an `<article>`
- mark task PIN-NEW-93 as done

This change addresses Phase 5 of the plan which calls for UI expansion and page improvements.

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68732c41b940832a91bb68485b3b5563