### PR TITLE
Add GitHub contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+ - Node version: `node -v`
+ - Browser [if relevant]:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+- Provide a concise description of your changes
+- Reference any relevant sections of [PLAN.md](../PLAN.md)
+- Update `tasks.yml` status if this PR completes a task
+
+## Testing
+- [ ] `pnpm test`
+- [ ] Lint and format checks

--- a/tasks.yml
+++ b/tasks.yml
@@ -1830,7 +1830,7 @@ phases:
     component: 'Community'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-94'


### PR DESCRIPTION
## Summary
- add Pull Request template reminding contributors to reference PLAN.md
- add bug report issue template
- mark task PIN-NEW-94 complete

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68732f5172f8832a8a3c073c727a828e