### PR TITLE
Stream search index generation

### DIFF
--- a/docs/scripts/build-search-index.md
+++ b/docs/scripts/build-search-index.md
@@ -2,7 +2,7 @@
 
 Creates a Lunr.js search index from markdown files under `content/` and writes it to `public/search-index.json`.
 
-The script walks the `content` directory recursively, reads front matter with `gray-matter`, and indexes each file's title and body for use in client-side search.
+The script walks the `content` directory recursively, streaming files one at a time. Each file's title and body is indexed with `gray-matter` and Lunr, while only minimal metadata is kept in memory. The final JSON is written via a Node stream to keep memory usage low.
 
 ## Environment Variables
 

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { createWriteStream } from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import lunr from 'lunr';
@@ -6,19 +7,17 @@ import matter from 'gray-matter';
 import { log } from './utils/logger.mjs';
 import { CONTENT_DIR, PUBLIC_DIR } from './utils/constants.mjs';
 
-// Recursively collect all markdown files for indexing
-async function collectMarkdown(dir) {
+// Async generator walking markdown files for indexing
+async function* walkMarkdown(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
-  const files = [];
   for (const entry of entries) {
     const res = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...(await collectMarkdown(res)));
+      yield* walkMarkdown(res);
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
-      files.push(res);
+      yield res;
     }
   }
-  return files;
 }
 
 // Convert a markdown path into a site-relative URL
@@ -29,35 +28,38 @@ function slugify(filePath) {
 
 // Build lunr.js index and write to public/search-index.json
 async function main() {
-  const files = await collectMarkdown(CONTENT_DIR);
+  const builder = new lunr.Builder();
+  builder.ref('url');
+  builder.field('title');
+  builder.field('body');
+
   const docs = [];
-  for (const file of files) {
+  for await (const file of walkMarkdown(CONTENT_DIR)) {
     const raw = await fs.readFile(file, 'utf8');
     const { data, content } = matter(raw);
-    docs.push({
+    const meta = {
       url: slugify(file),
       title: data.title || path.basename(file, '.md'),
-      body: content,
-    });
+    };
+    builder.add({ ...meta, body: content });
+    docs.push(meta);
   }
 
-  const idx = lunr(function () {
-    this.ref('url');
-    this.field('title');
-    this.field('body');
-    docs.forEach((doc) => this.add(doc));
-  });
+  const idx = builder.build();
 
-  const output = { index: idx.toJSON(), docs };
   await fs.mkdir(PUBLIC_DIR, { recursive: true });
-  await fs.writeFile(
-    path.join(PUBLIC_DIR, 'search-index.json'),
-    JSON.stringify(output)
-  );
-  log.info(`Wrote ${path.join(PUBLIC_DIR, 'search-index.json')}`);
+  const outPath = path.join(PUBLIC_DIR, 'search-index.json');
+  const stream = createWriteStream(outPath);
+  stream.write('{"index":');
+  stream.write(JSON.stringify(idx.toJSON()));
+  stream.write(',"docs":');
+  stream.write(JSON.stringify(docs));
+  stream.write('}');
+  await new Promise((resolve) => stream.end(resolve));
+  log.info(`Wrote ${outPath}`);
 }
 
-export { collectMarkdown, slugify, main };
+export { walkMarkdown, slugify, main };
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((err) => {

--- a/tasks.yml
+++ b/tasks.yml
@@ -1902,7 +1902,7 @@ phases:
     component: 'Performance'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-98'


### PR DESCRIPTION
## Summary
- refactor `build-search-index.mjs` to stream file processing
- stream output JSON to reduce memory
- document the low-memory approach in `docs/scripts/build-search-index.md`
- mark Streamlined Search Indexing task complete in `tasks.yml`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873374b4f9c832a93f097c28d594658