### PR TITLE
Add configurable log levels

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -24,6 +24,8 @@ This guide collects tips for diagnosing failures in the GitHub Actions pipeline 
    ```bash
    export GH_TOKEN=...
    export OPENAI_API_KEY=...
+   # Optional: adjust logging verbosity
+   export LOG_LEVEL=DEBUG
    ```
 3. Execute the script directly using Node 20:
    ```bash

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -4,6 +4,8 @@
 This directory contains documentation for the Node.js scripts that run during the CI workflow. Each script is written in ESM and executed with Node 20.
 All pages include example commands and sample output so you can reproduce the results locally.
 
+All scripts respect a `LOG_LEVEL` environment variable. Set it to `DEBUG`, `INFO`, `WARN` or `ERROR` to control verbosity (default: `INFO`).
+
 | Script               | Description                                                              | Environment Variables                     |
 | -------------------- | ------------------------------------------------------------------------ | ----------------------------------------- |
 | `fetch-gh-repos.mjs` | Fetches public repositories from GitHub and creates tool markdown files. | `GH_TOKEN`, optional `GH_USER`            |

--- a/docs/scripts/agent-bus.md
+++ b/docs/scripts/agent-bus.md
@@ -6,6 +6,7 @@ Reads all YAML agent manifests in `content/agents`, aggregates their status, and
 
 - `GH_TOKEN` – **required** token for creating or updating issues.
 - `GH_REPO` – optional `owner/repo` override. Defaults to `GITHUB_REPOSITORY`.
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
 
 Run manually with:
 

--- a/docs/scripts/build-insights.md
+++ b/docs/scripts/build-insights.md
@@ -12,6 +12,7 @@ Output is logged with `[INFO]`, `[WARN]`, and `[ERROR]` prefixes via `logger.mjs
 
 - `OPENAI_API_KEY` – **required** for contacting the OpenAI API.
 - `OPENAI_MODEL` – optional model name (defaults to `gpt-3.5-turbo-1106`).
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
 
 Run manually with:
 

--- a/docs/scripts/build-rss.md
+++ b/docs/scripts/build-rss.md
@@ -7,6 +7,7 @@ This script walks the `content` directory recursively, reads front-matter using 
 ## Environment Variables
 
 - `BASE_URL` – optional root URL for the feed. Defaults to `https://adrianwedd.github.io`.
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
 
 Run manually with:
 

--- a/docs/scripts/build-search-index.md
+++ b/docs/scripts/build-search-index.md
@@ -7,6 +7,7 @@ The script walks the `content` directory recursively, streaming files one at a t
 ## Environment Variables
 
 None.
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
 
 Run manually with:
 

--- a/docs/scripts/check-dns.md
+++ b/docs/scripts/check-dns.md
@@ -4,7 +4,7 @@ Checks DNS records for the custom domain listed in the `CNAME` file. The script 
 
 ## Environment Variables
 
-None.
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
 
 Run manually with:
 

--- a/docs/scripts/classify-inbox.md
+++ b/docs/scripts/classify-inbox.md
@@ -8,6 +8,7 @@ To avoid concurrent runs processing the same file, the script creates a `.lock` 
 
 - `OPENAI_API_KEY` – **required** for contacting the OpenAI API.
 - `OPENAI_MODEL` – optional model name (defaults to `gpt-3.5-turbo-1106`).
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
 
 Run manually with:
 

--- a/docs/scripts/fetch-gh-repos.md
+++ b/docs/scripts/fetch-gh-repos.md
@@ -6,6 +6,7 @@ Fetches repositories from GitHub for a given user and generates markdown files i
 
 - `GH_TOKEN` – **required**. GitHub token used to authenticate API calls.
 - `GH_USER` – optional override for the user whose repositories are fetched. Defaults to the user associated with `GH_TOKEN`.
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
 
 Run manually with:
 

--- a/scripts/utils/logger.mjs
+++ b/scripts/utils/logger.mjs
@@ -1,16 +1,35 @@
 /**
- * Lightweight logging wrapper to allow DEBUG control.
+ * Simple logging utility with adjustable log levels.
+ *
+ * Set `LOG_LEVEL` to one of `DEBUG`, `INFO`, `WARN`, or `ERROR` to control
+ * verbosity. Defaults to `INFO`. Messages below the configured level are
+ * suppressed. `process.env.DEBUG` is treated the same as `LOG_LEVEL=DEBUG` for
+ * backwards compatibility.
+ *
  * @namespace log
  * @property {(...args: any[]) => void} info  Log an informational message.
  * @property {(...args: any[]) => void} warn  Log a warning message.
  * @property {(...args: any[]) => void} error Log an error message.
- * @property {(...args: any[]) => void} debug Log when `DEBUG` is enabled.
+ * @property {(...args: any[]) => void} debug Log a debug message.
  */
+
+const levelMap = { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 };
+const envLevel = process.env.LOG_LEVEL || (process.env.DEBUG ? 'DEBUG' : 'INFO');
+const currentLevel = levelMap[envLevel.toUpperCase()] ?? levelMap.INFO;
+
+const shouldLog = (level) => levelMap[level] >= currentLevel;
+
 export const log = {
-  info: (...args) => console.log('[INFO]', ...args),
-  warn: (...args) => console.warn('[WARN]', ...args),
-  error: (...args) => console.error('[ERROR]', ...args),
+  info: (...args) => {
+    if (shouldLog('INFO')) console.log('[INFO]', ...args);
+  },
+  warn: (...args) => {
+    if (shouldLog('WARN')) console.warn('[WARN]', ...args);
+  },
+  error: (...args) => {
+    if (shouldLog('ERROR')) console.error('[ERROR]', ...args);
+  },
   debug: (...args) => {
-    if (process.env.DEBUG) console.debug('[DEBUG]', ...args);
+    if (shouldLog('DEBUG')) console.debug('[DEBUG]', ...args);
   },
 };

--- a/tasks.yml
+++ b/tasks.yml
@@ -1920,7 +1920,7 @@ phases:
     component: 'Robustness'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-99'


### PR DESCRIPTION
## Summary
- allow scripts to control verbosity using `LOG_LEVEL`
- document the new variable in the script docs and debugging guide
- mark task PIN-NEW-99 as done

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687339daa6b8832aa8e777b892aef5ac