### PR TITLE
Parallelize RSS and search index jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,29 +2,27 @@
 name: Build & Deploy Site
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ['main']
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Minimal permissions for deployment
 permissions:
   contents: write
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: 'pages'
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build & Process
+  process:
+    name: Process Content
     runs-on: ubuntu-latest
+    outputs:
+      changed-content: ${{ steps.changed-content.outputs.any_changed }}
+      pages-origin: ${{ steps.pages.outputs.origin }}
+      pages-base: ${{ steps.pages.outputs.base_path }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,7 +71,6 @@ jobs:
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
 
-      # --- Custom Script Execution Steps ---
       - name: Security Audit
         run: npm audit --audit-level=high
 
@@ -99,10 +96,133 @@ jobs:
           node scripts/classify-inbox.mjs ${{ steps.changed-files.outputs.all_changed_files }}
           node scripts/build-insights.mjs ${{ steps.changed-files.outputs.all_changed_files }}
           node scripts/agent-bus.mjs
-          if [ "${{ steps.changed-content.outputs.any_changed }}" = 'true' ]; then
-            node scripts/build-search-index.mjs
-            node scripts/build-rss.mjs
+
+      - name: Archive workspace
+        run: tar -czf workspace.tar.gz .
+
+      - name: Upload workspace
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace
+          path: workspace.tar.gz
+
+  indexing:
+    name: Generate RSS & Search
+    needs: process
+    if: needs.process.outputs.changed-content == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        script: [build-search-index.mjs, build-rss.mjs]
+    steps:
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+          path: .
+      - run: tar -xzf workspace.tar.gz
+
+      - name: Detect package manager
+        id: detect-package-manager
+        run: |
+          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
+            echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
+            exit 0
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+            echo "lockfile=package-lock.json" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Unable to determine package manager"
+            exit 1
           fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+          cache-dependency-path: ./${{ steps.detect-package-manager.outputs.lockfile }}
+
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+
+      - name: Run ${{ matrix.script }}
+        env:
+          BASE_URL: ${{ needs.process.outputs.pages-origin }}${{ needs.process.outputs.pages-base }}
+        run: node scripts/${{ matrix.script }}
+
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.script }}
+          path: ${{ matrix.script == 'build-rss.mjs' && 'public/rss.xml' || 'public/search-index.json' }}
+
+  build:
+    name: Build and Deploy
+    needs: [process, indexing]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+          path: .
+      - run: tar -xzf workspace.tar.gz
+
+      - name: Download search index
+        uses: actions/download-artifact@v4
+        with:
+          name: build-search-index.mjs
+          path: .
+
+      - name: Download RSS
+        uses: actions/download-artifact@v4
+        with:
+          name: build-rss.mjs
+          path: .
+
+      - name: Detect package manager
+        id: detect-package-manager
+        run: |
+          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
+            echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
+            exit 0
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+            echo "lockfile=package-lock.json" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Unable to determine package manager"
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+          cache-dependency-path: ./${{ steps.detect-package-manager.outputs.lockfile }}
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+
+      - name: Ensure artifact paths
+        run: mkdir -p public
 
       - name: Build with Astro
         run: |
@@ -115,4 +235,3 @@ jobs:
         with:
           branch: gh-pages
           folder: dist
-

--- a/tasks.yml
+++ b/tasks.yml
@@ -1956,7 +1956,7 @@ phases:
     component: 'CI/CD'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-101'


### PR DESCRIPTION
## Summary
- break deploy workflow into multiple jobs
- run search index and RSS generation in parallel
- update tasks.yml to mark workflow parallelization complete

## Testing
- `pnpm install --no-frozen-lockfile`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68733f42a788832a9ebd754ce394b8b0