### PR TITLE
Enforce collection schemas

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -29,19 +29,19 @@ Build a self-updating, agent-fed, static knowledge hub—a "personal intelligenc
 
 ### 2. Tech Stack Overview
 
-| Layer            | Choice / Notes                                        |
-| ---------------- | ----------------------------------------------------- |
-| Static Framework | Astro v4 (output: "static")                           |
-| Styling          | Tailwind CSS v3                                       |
-| Diagrams         | Mermaid.js (client-side)                              |
-| Markdown-with-JS | MDX (built-in to Astro)                               |
-| CI / CD          | GitHub Actions + JamesIves/github-pages-deploy-action |
-| Testing          | Vitest with coverage enforced                         |
-| Agent Scripting  | Node 20 ESM (`*.mjs` scripts)                         |
-| LLM APIs         | OpenAI, Gemini, or other—invoked from CI scripts      |
-| Code Quality     | ESLint and Prettier                                   |
-| Markdown Plugins | rehype-external-links for external link security      |
-| Image Optimization | @astrojs/image with sharp for responsive images      |
+| Layer              | Choice / Notes                                        |
+| ------------------ | ----------------------------------------------------- |
+| Static Framework   | Astro v4 (output: "static")                           |
+| Styling            | Tailwind CSS v3                                       |
+| Diagrams           | Mermaid.js (client-side)                              |
+| Markdown-with-JS   | MDX (built-in to Astro)                               |
+| CI / CD            | GitHub Actions + JamesIves/github-pages-deploy-action |
+| Testing            | Vitest with coverage enforced                         |
+| Agent Scripting    | Node 20 ESM (`*.mjs` scripts)                         |
+| LLM APIs           | OpenAI, Gemini, or other—invoked from CI scripts      |
+| Code Quality       | ESLint and Prettier                                   |
+| Markdown Plugins   | rehype-external-links for external link security      |
+| Image Optimization | @astrojs/image with sharp for responsive images       |
 
 ---
 
@@ -98,18 +98,24 @@ description: Handles GitHub automation tasks.
 The `agent-bus.mjs` script reads these manifests and updates the `#agent-bus`
 GitHub Issue with a summary table.
 
+### 3c. Content Schemas
+
+Each section under `content/` has its own Astro collection schema defined in
+`src/content/config.ts`. The build fails if a Markdown file's frontmatter does
+not satisfy the schema for its directory.
+
 ### 4. Automation Scripts (CI)
 
 All automation scripts accept a `--dry-run` flag to log actions without modifying files or remote resources.
 
-| Script                   | Purpose                                                                                                                                                                              | Invoked By            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
-| `fetch-gh-repos.mjs`     | Scan GitHub user/org, create `content/tools/<repo>.md` for any repo tagged tool.                                                                                                     | Manual & nightly cron |
+| Script                   | Purpose                                                                                                                                                                                                                                                                             | Invoked By            |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `fetch-gh-repos.mjs`     | Scan GitHub user/org, create `content/tools/<repo>.md` for any repo tagged tool.                                                                                                                                                                                                    | Manual & nightly cron |
 | `classify-inbox.mjs`     | For every file in `content/inbox/`, call LLM → `{section,tags,confidence,reasoning}`. Files with confidence ≥ 0.8 go to their section; lower confidence files move to `review-needed/` with reasoning attached. Unknown sections go to `untagged/`. Uses `.lock` files and caching. | Before build step     |
-| `build-insights.mjs`     | Parse new/changed markdown (logs, garden, mirror); generate `<slug>.insight.md` with summary + cross-links. Caches summaries by file hash to avoid redundant LLM calls.                                                                          | After classification  |
-| `build-search-index.mjs` | Generate `public/search-index.json` for client-side Lunr search.                                                                                                                     | Before build step     |
-| `build-rss.mjs`          | Generate `public/rss.xml` feed from markdown metadata.                                                                                                                               | Before deploy step    |
-| `agent-bus.mjs`          | Read `content/agents/*.yml`, update or create GitHub Issue `#agent-bus` with latest agent statuses.                                                                                  | Last step in workflow |
+| `build-insights.mjs`     | Parse new/changed markdown (logs, garden, mirror); generate `<slug>.insight.md` with summary + cross-links. Caches summaries by file hash to avoid redundant LLM calls.                                                                                                             | After classification  |
+| `build-search-index.mjs` | Generate `public/search-index.json` for client-side Lunr search.                                                                                                                                                                                                                    | Before build step     |
+| `build-rss.mjs`          | Generate `public/rss.xml` feed from markdown metadata.                                                                                                                                                                                                                              | Before deploy step    |
+| `agent-bus.mjs`          | Read `content/agents/*.yml`, update or create GitHub Issue `#agent-bus` with latest agent statuses.                                                                                                                                                                                 | Last step in workflow |
 
 ---
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,12 +8,30 @@ const baseSchema = z.object({
   status: z.enum(['draft', 'published', 'archived']).default('draft'),
 });
 
+const toolsSchema = z.object({
+  title: z.string(),
+  repo: z.string().url(),
+  description: z.string(),
+  updated: z.string().optional(),
+});
+
+const agentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  role: z.string().optional(),
+  owner: z.string().optional(),
+  status: z.enum(['active', 'idle', 'offline', 'error']),
+  last_updated: z.string(),
+  description: z.string().optional(),
+});
+
 const garden = defineCollection({ type: 'content', schema: baseSchema });
 const codex = defineCollection({ type: 'content', schema: baseSchema });
 const logs = defineCollection({ type: 'content', schema: baseSchema });
 const mirror = defineCollection({ type: 'content', schema: baseSchema });
-const tools = defineCollection({ type: 'content', schema: baseSchema });
+const tools = defineCollection({ type: 'content', schema: toolsSchema });
 const resume = defineCollection({ type: 'content', schema: baseSchema });
+const agents = defineCollection({ type: 'data', schema: agentSchema });
 
 export const collections = {
   garden,
@@ -22,4 +40,5 @@ export const collections = {
   mirror,
   tools,
   resume,
+  agents,
 };

--- a/tasks.yml
+++ b/tasks.yml
@@ -2028,7 +2028,7 @@ phases:
     component: 'Architecture'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-105'


### PR DESCRIPTION
## Summary
- define content schemas per directory in `src/content/config.ts`
- document build-time schema checks in `PLAN.md`
- mark task 105 as done in `tasks.yml`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68735048d8b8832a930e559181fa6d6d