### PR TITLE
Implement content status field

### DIFF
--- a/content/inbox/manual-trigger.md
+++ b/content/inbox/manual-trigger.md
@@ -1,1 +1,9 @@
+---
+title: Test CI trigger
+date: 2025-01-01T00:00:00Z
+tags: []
+description: Trigger CI workflow for testing.
+status: draft
+---
+
 # Test CI trigger

--- a/docs/scripts/build-rss.md
+++ b/docs/scripts/build-rss.md
@@ -1,8 +1,8 @@
 # build-rss.mjs
 
-Generates an RSS 2.0 feed from all markdown files under `content/` and writes it to `public/rss.xml`.
+Generates an RSS 2.0 feed from published markdown files under `content/` and writes it to `public/rss.xml`.
 
-This script walks the `content` directory recursively, reads front-matter using `gray-matter`, and sorts entries by their `date` field (or file modification time). The output RSS contains basic metadata like title, link, description and publication date.
+This script walks the `content` directory recursively, reads front-matter using `gray-matter`, and sorts entries by their `date` field (or file modification time). Only notes with `status: published` are included in the feed. The output RSS contains basic metadata like title, link, description and publication date.
 
 ## Environment Variables
 

--- a/docs/scripts/build-search-index.md
+++ b/docs/scripts/build-search-index.md
@@ -1,6 +1,7 @@
 # build-search-index.mjs
 
-Creates a Lunr.js search index from markdown files under `content/` and writes it to `public/search-index.json`.
+Creates a Lunr.js search index from published markdown files under `content/` and writes it to `public/search-index.json`.
+Only notes with `status: published` are indexed.
 
 The script walks the `content` directory recursively, streaming files one at a time. Each file's title and body is indexed with `gray-matter` and Lunr, while only minimal metadata is kept in memory. The final JSON is written via a Node stream to keep memory usage low.
 

--- a/scripts/build-rss.mjs
+++ b/scripts/build-rss.mjs
@@ -69,6 +69,10 @@ async function main() {
   for (const file of files) {
     const raw = await fs.readFile(file, 'utf8');
     const { data, content } = matter(raw);
+    const status = data.status || 'draft';
+    if (status !== 'published') {
+      continue;
+    }
     const stats = await fs.stat(file);
     const title = data.title || path.basename(file, '.md');
     const description = data.description || content.split('\n')[0];

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -42,6 +42,10 @@ async function main() {
   for await (const file of walkMarkdown(CONTENT_DIR)) {
     const raw = await fs.readFile(file, 'utf8');
     const { data, content } = matter(raw);
+    const status = data.status || 'draft';
+    if (status !== 'published') {
+      continue;
+    }
     const meta = {
       url: slugify(file),
       title: data.title || path.basename(file, '.md'),

--- a/scripts/classify-inbox.mjs
+++ b/scripts/classify-inbox.mjs
@@ -235,7 +235,7 @@ async function main() {
     log.info(`Processing ${name}`);
     let targetDir;
     let tags = [];
-    let extra = {};
+    let extra = { status: 'draft' };
 
     try {
       const result = await classifyFile(filePath);
@@ -244,7 +244,7 @@ async function main() {
       } else if (result.confidence < 0.8) {
         targetDir = REVIEW_NEEDED_DIR;
         tags = result.tags || [];
-        extra = { confidence: result.confidence, reasoning: result.reasoning };
+        extra = { status: 'draft', confidence: result.confidence, reasoning: result.reasoning };
       } else {
         targetDir = path.join(CONTENT_DIR, result.section);
         if (result.tags && result.tags.length) {

--- a/tasks.yml
+++ b/tasks.yml
@@ -2046,7 +2046,7 @@ phases:
     component: 'Architecture'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-106'

--- a/test/classify-inbox.test.mjs
+++ b/test/classify-inbox.test.mjs
@@ -128,7 +128,7 @@ describe('classify-inbox.mjs', () => {
     await classifyInbox.main();
     expect(fs.writeFile).toHaveBeenCalledWith(
       expect.stringContaining('content/untagged/file1.txt'),
-      'Test content'
+      expect.stringContaining('status: draft')
     );
     expect(fs.unlink).toHaveBeenCalledWith(
       expect.stringContaining('content/inbox/file1.txt')


### PR DESCRIPTION
## Summary
- add `status` to frontmatter
- filter unpublished items in RSS and search index builds
- set `status: draft` on classified notes
- document new behaviour and update tests
- mark lifecycle task complete

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68735212f304832aafd5d0de9925b9e4