### PR TITLE
Improve LLM prompt assertions

### DIFF
--- a/test/build-insights.test.mjs
+++ b/test/build-insights.test.mjs
@@ -88,10 +88,13 @@ describe('build-insights.mjs', () => {
   it('processMarkdownFile should generate an insight file', async () => {
     const filePath = path.join('content', 'garden', 'file1.md');
     await buildInsights.processMarkdownFile(filePath);
-    expect(callOpenAI).toHaveBeenCalledWith(
-      buildInsights.buildSummaryPrompt(mockMarkdownContent, 'garden'),
-      expect.any(String)
+    const [prompt] = callOpenAI.mock.calls[0];
+    const expected = buildInsights.buildSummaryPrompt(
+      mockMarkdownContent,
+      'garden'
     );
+    expect(prompt).toBe(expected);
+    expect(callOpenAI).toHaveBeenCalledWith(expected, expect.any(String));
     expect(writeFile).toHaveBeenCalledWith(
       path.join('content', 'garden', 'file1.insight.md'),
       mockSummary

--- a/test/classify-inbox.test.mjs
+++ b/test/classify-inbox.test.mjs
@@ -88,6 +88,11 @@ describe('classify-inbox.mjs', () => {
       reasoning: 'clear topic',
     });
     await classifyInbox.main();
+
+    const sentPrompt = callOpenAI.mock.calls[0][0];
+    const expectedPrompt = await classifyInbox.buildPrompt('Test content');
+    expect(sentPrompt).toBe(expectedPrompt);
+
     expect(fs.writeFile).toHaveBeenCalledWith(
       expect.stringContaining('content/garden/file1.txt'),
       expect.stringContaining('---')


### PR DESCRIPTION
## Summary
- capture LLM prompts from mock calls in tests
- ensure classify-inbox and build-insights tests assert exact prompts

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68735780fb64832aa2bc10b1e3e3ec15