### PR TITLE
Add fast-check tests for sanitizeMarkdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.1",
     "execa": "^8.0.0",
+    "fast-check": "^4.2.0",
     "husky": "^9.1.7",
     "markdownlint": "^0.38.0",
     "prettier": "^3.6.2",

--- a/tasks.yml
+++ b/tasks.yml
@@ -2100,7 +2100,7 @@ phases:
     component: 'Testing'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-109'

--- a/test/utils/sanitize-markdown.test.mjs
+++ b/test/utils/sanitize-markdown.test.mjs
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { sanitizeMarkdown } from '../../scripts/utils/sanitize-markdown.mjs';
+
+describe('sanitizeMarkdown', () => {
+  it('strips script tags from input', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (before, after) => {
+        const input = `${before}<script>alert(1)</script>${after}`;
+        const output = sanitizeMarkdown(input);
+        expect(output).not.toMatch(/<script/i);
+      })
+    );
+  });
+
+  it('removes event handler attributes', () => {
+    fc.assert(
+      fc.property(fc.string(), (payload) => {
+        const input = `<img src="x" onerror="${payload}">`;
+        const output = sanitizeMarkdown(input);
+        expect(output).not.toMatch(/onerror/i);
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `fast-check` devDependency
- test `sanitizeMarkdown` removes `<script>` tags and event attributes
- mark sanitization property tests task done in `tasks.yml`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68735c2db220832aa3a0e03bbbab36a6