### PR TITLE
Add scheduled DNS check workflow

### DIFF
--- a/.github/workflows/dns-check.yml
+++ b/.github/workflows/dns-check.yml
@@ -1,0 +1,21 @@
+name: DNS Check
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  dns:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run DNS check
+        run: node scripts/check-dns.mjs

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -15,7 +15,7 @@ Pass `--dry-run` to preview actions without making changes.
 | `build-search-index.mjs` | Builds `public/search-index.json` for site search. | none |
 | `build-rss.mjs` | Generates `public/rss.xml` from markdown metadata. | optional `BASE_URL` (defaults to `https://adrianwedd.github.io`) |
 | `agent-bus.mjs`      | Aggregates agent manifests and posts a summary issue on GitHub.          | `GH_TOKEN`, optional `GH_REPO`            |
-| `check-dns.mjs`      | Verifies A and CNAME records for the custom domain from `CNAME`. | none |
+| `check-dns.mjs`      | Verifies A and CNAME records for the custom domain from `CNAME`. Runs hourly via GitHub Actions. | none |
 
 See the individual files below for further details.
 

--- a/docs/scripts/check-dns.md
+++ b/docs/scripts/check-dns.md
@@ -1,6 +1,6 @@
 # check-dns.mjs
 
-Checks DNS records for the custom domain listed in the `CNAME` file. The script verifies that the domain resolves to GitHub Pages by looking for either the standard A records or a CNAME pointing to `*.github.io`.
+Checks DNS records for the custom domain listed in the `CNAME` file. The script verifies that the domain resolves to GitHub Pages by looking for either the standard A records or a CNAME pointing to `*.github.io`. It runs automatically each hour via the `DNS Check` GitHub Actions workflow.
 
 ## Environment Variables
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -2136,7 +2136,7 @@ phases:
     component: 'CI/CD'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-111'


### PR DESCRIPTION
## Summary
- create new `dns-check.yml` workflow to run `check-dns.mjs` hourly
- note the schedule in script documentation
- mark task PIN-NEW-111 as done in `tasks.yml`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687363b5f344832a93188aedde59b492