### PR TITLE
Add project architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pnpm run dev
 - `.github/workflows/` – CI configuration for building and deploying the site
 - `docs/` – Additional architecture and script documentation
 
+## Project Architecture
+
+For an overview of the automation pipeline see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 ## Environment Variables
 
 The CI pipeline expects several secrets configured under **GitHub repository settings → Secrets**:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,21 @@
 
 This document explains how the Personal Intelligence Node works today. It focuses on the current data flow and automation pipeline.
 
+## Directory Layout
+
+```
+.
+├── .github/workflows/     # CI pipelines
+├── scripts/               # Node automation tasks
+├── content/               # Markdown source data
+│   ├── inbox/             # Unsorted contributions
+│   └── agents/            # Agent manifests
+└── public/                # Static assets and generated files
+```
+
 ## Components
+- **LLM Integration** – OpenAI is used by `classify-inbox.mjs` and `build-insights.mjs` for tagging and summarising content.
+
 
 - **Content Repository** – Markdown files live under `content/`. Agents drop new files in `content/inbox/` and update their manifests in `content/agents/`.
 - **Node Scripts** – Automation tasks are implemented as ESM scripts in `scripts/`:

--- a/tasks.yml
+++ b/tasks.yml
@@ -2154,7 +2154,7 @@ phases:
     component: 'Documentation'
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     type: task
     command: null
     task_id: 'PIN-NEW-112'


### PR DESCRIPTION
## Summary
- document directory layout and pipeline
- link architecture docs from README
- mark architecture doc task as done

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873862560c4832a80230470737156ba