### PR TITLE
Document gh-pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ The CI pipeline expects several secrets configured under **GitHub repository set
 
 Set these as secrets before running the workflows.
 
+## Deployment
+
+Pushing to `main` runs the workflow in `.github/workflows/deploy.yml` which builds the Astro site and publishes `dist` to the `gh-pages` branch. GitHub Pages then serves the site from that branch.
+
+
 ## Development
 
 Install dependencies and run the dev server:

--- a/status.json
+++ b/status.json
@@ -1,0 +1,7 @@
+{
+  "codex-agent": {
+    "status": "running",
+    "updated": "2025-07-13T23:22:15Z",
+    "message": "prepare gh-pages deployment instructions"
+  }
+}


### PR DESCRIPTION
## Summary
- document how GitHub Actions deploys the site to gh-pages
- record current agent activity in `status.json`

## Testing
- `pnpm test`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_68743f05071c832aaaa0a669a4be859e