### PR TITLE
Add GitHub Pages troubleshooting guide

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+github.adrianwedd.com

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Format the codebase using Prettier:
 pnpm run format
 ```
 
-See [docs/scripts/README.md](docs/scripts/README.md) for script usage and environment variables. Troubleshooting tips live in [docs/DEBUGGING.md](docs/DEBUGGING.md). Current technical challenges are summarised in [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md).
+See [docs/scripts/README.md](docs/scripts/README.md) for script usage and environment variables. Troubleshooting tips live in [docs/DEBUGGING.md](docs/DEBUGGING.md). Additional steps for Pages errors are in [docs/TROUBLESHOOTING_PAGES.md](docs/TROUBLESHOOTING_PAGES.md). Current technical challenges are summarised in [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md).
 
 ## License
 

--- a/docs/TROUBLESHOOTING_PAGES.md
+++ b/docs/TROUBLESHOOTING_PAGES.md
@@ -1,0 +1,13 @@
+# GitHub Pages Troubleshooting
+
+This guide outlines common checks when your site returns a 404 error.
+
+1. **GitHub Status** – confirm `https://www.githubstatus.com` reports no active incidents.
+2. **DNS Records** – run `node scripts/check-dns.mjs` to verify the domain in `CNAME` resolves to GitHub Pages IPs or a `github.io` CNAME.
+3. **Browser Cache** – clear your browser cache if the repository is private and you still see outdated content.
+4. **Entry File** – ensure the repository's publishing source contains an `index.html` or `index.md` at the top level. The Astro build outputs `dist/index.html` which is deployed to the `gh-pages` branch.
+5. **Publishing Source** – confirm the repository settings point GitHub Pages at the `gh-pages` branch.
+6. **Custom Domain** – if using a custom domain, verify a `CNAME` file exists with the correct hostname.
+7. **GitHub Actions** – check the `deploy.yml` workflow completes successfully and that a `.nojekyll` file is present if you disable Actions.
+
+Running through these steps locally can help diagnose deployment issues before opening a community discussion.

--- a/status.json
+++ b/status.json
@@ -1,7 +1,7 @@
 {
   "codex-agent": {
     "status": "running",
-    "updated": "2025-07-13T23:22:15Z",
-    "message": "prepare gh-pages deployment instructions"
+    "updated": "2025-07-13T23:39:42Z",
+    "message": "updated troubleshooting docs"
   }
 }


### PR DESCRIPTION
## Summary
- document steps for debugging 404 errors in `docs/TROUBLESHOOTING_PAGES.md`
- reference the new guide in README
- add `CNAME` file for custom domain checks
- update agent status

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6874415fe9e4832ab58fc81f968f4f41