### PR TITLE
Add SECURITY policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ See [docs/scripts/README.md](docs/scripts/README.md) for script usage and enviro
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Security
+
+For details on reporting vulnerabilities, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+If you discover a vulnerability in this project, please avoid filing public issues.
+
+## Reporting a Vulnerability
+
+Email [security@adrianwedd.com](mailto:security@adrianwedd.com) with a description of the problem. You can also open a pull request from a temporary **private** fork if you already have a fix.
+
+We will work with you to resolve the issue before any public disclosure.

--- a/tasks.yml
+++ b/tasks.yml
@@ -2426,3 +2426,23 @@ phases:
       - 'CONTRIBUTING.md directs reporters to a private disclosure method.'
     assigned_to: 'codex-agent'
     epic: 'Phase 9: Improvements'
+
+  - id: 127
+    title: 'Publish SECURITY policy'
+    description: 'Create SECURITY.md summarizing disclosure steps and link to README.'
+    component: 'Documentation'
+    dependencies: []
+    priority: 2
+    status: done
+    type: task
+    command: null
+    task_id: 'PIN-NEW-127'
+    area: 'Security'
+    actionable_steps:
+      - 'Write SECURITY.md referencing security@adrianwedd.com for private reports.'
+      - 'Link SECURITY.md from README.'
+    acceptance_criteria:
+      - 'Repository contains SECURITY.md matching CONTRIBUTING guidance.'
+      - 'README links to the security policy.'
+    assigned_to: 'codex-agent'
+    epic: 'Phase 9: Improvements'


### PR DESCRIPTION
## Summary
- add SECURITY.md describing private vulnerability reporting
- reference SECURITY.md from README
- record the new documentation task in `tasks.yml`

## Testing
- `pnpm test`
- `pnpm run lint`
- `pnpm run format`

------
https://chatgpt.com/codex/tasks/task_e_68746e8e1464832aa1921ccce653fd42