### PR TITLE
Add documentation for retry-failed script

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -16,6 +16,7 @@ Pass `--dry-run` to preview actions without making changes.
 | `build-rss.mjs` | Generates `public/rss.xml` from markdown metadata. | optional `BASE_URL` (defaults to `https://adrianwedd.github.io`) |
 | `agent-bus.mjs`      | Aggregates agent manifests and posts a summary issue on GitHub.          | `GH_TOKEN`, optional `GH_REPO`            |
 | `check-dns.mjs`      | Verifies A, AAAA and CNAME records for the custom domain from `CNAME`. Runs hourly via GitHub Actions. | none |
+| `retry-failed.mjs`   | Reprocesses files in `content/inbox/failed` and `content/insights-failed` using the same logic as the main scripts. | `OPENAI_API_KEY`, optional `OPENAI_MODEL` |
 
 See the individual files below for further details.
 

--- a/docs/scripts/retry-failed.md
+++ b/docs/scripts/retry-failed.md
@@ -1,0 +1,27 @@
+# retry-failed.mjs
+
+Attempts to recover files that previously failed automated processing. The script scans `content/inbox/failed` and `content/insights-failed`, then re-runs classification and insight generation using the same logic as `classify-inbox.mjs` and `build-insights.mjs`.
+
+For inbox failures it reclassifies the file and moves it to the correct section, `review-needed`, or `untagged`. For insight failures it first reclassifies the file, moves it accordingly, and then generates an insight next to the new location.
+
+## Environment Variables
+
+- `OPENAI_API_KEY` – **required** for contacting the OpenAI API.
+- `OPENAI_MODEL` – optional model name (defaults to `gpt-3.5-turbo-1106`).
+- `LOG_LEVEL` – optional log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`).
+
+Pass `--dry-run` to log intended actions without moving or writing files.
+
+Run manually with:
+
+```bash
+OPENAI_API_KEY=sk-test node scripts/retry-failed.mjs
+OPENAI_API_KEY=sk-test node scripts/retry-failed.mjs --dry-run
+```
+
+Example output:
+
+```text
+[INFO] Reclassified file1.txt -> content/garden/file1.txt
+[INFO] Moved note.md -> content/garden/note.md
+```


### PR DESCRIPTION
## Summary
- document `retry-failed.mjs` with usage details
- include the new script in the automation scripts overview table

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6874b92d38cc832a9b2f5db4f30c3c26