### PR TITLE
Update README with OPENAI_API_KEY usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The CI pipeline expects several secrets configured under **GitHub repository set
 | Name                | Used By                           | Purpose                            |
 | ------------------- | --------------------------------- | ---------------------------------- |
 | `GH_TOKEN`          | fetch-gh-repos.mjs, agent-bus.mjs | Minimal GitHub token for API calls |
-| `OPENAI_API_KEY`    | classify-inbox.mjs                | Access to OpenAI API               |
+| `OPENAI_API_KEY`    | classify-inbox.mjs, build-insights.mjs, retry-failed.mjs | Access to OpenAI API               |
 | `SLACK_WEBHOOK_URL` | deploy workflow                   | Post CI failure notifications      |
 
 Set these as secrets before running the workflows.


### PR DESCRIPTION
## Summary
- document that `retry-failed.mjs` and `build-insights.mjs` also need `OPENAI_API_KEY`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6874bba63788832aa892bbe15c3bdba3