### PR TITLE
Add retry-failed docs

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -22,3 +22,4 @@ See the individual files below for further details.
 
 - [build-search-index.mjs](build-search-index.md) – builds `public/search-index.json` for Lunr search.
 - [build-rss.mjs](build-rss.md) – generates the site's RSS feed.
+- [retry-failed.mjs](retry-failed.md) – reprocesses failed inbox and insight files.


### PR DESCRIPTION
## Summary
- create documentation for the `retry-failed` utility
- link the doc from the scripts README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6874c0f407d8832abf0ff479029bd26b